### PR TITLE
move container-engine to yaml

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -74,10 +74,7 @@ def run(
 
 
 @linker.command()
-@click.argument(
-    "container_engine",
-    type=click.Choice(["docker", "singularity", "unknown"]),
-)
+@click.argument("container_engine")
 @click.argument(
     "results_dir",
     type=click.Path(exists=True, resolve_path=True),

--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, Set, Union
+from typing import Dict, Tuple, Union
 
 import yaml
 from loguru import logger
@@ -72,13 +72,13 @@ class Config:
                 )
         return self._load_yaml(filepath)
 
-    def _get_steps(self) -> Set:
-        spec_steps = set([x for x in self.pipeline["steps"]])
-        steps = set([x for x in spec_steps if x in STEP_ORDER])
-        unknown_steps = spec_steps.difference(STEP_ORDER)
+    def _get_steps(self) -> Tuple:
+        spec_steps = tuple([x for x in self.pipeline["steps"]])
+        steps = tuple([x for x in spec_steps if x in STEP_ORDER])
+        unknown_steps = tuple([x for x in spec_steps if x not in STEP_ORDER])
         if unknown_steps:
             logger.warning(
                 f"Unknown steps are included in the pipeline specification: {unknown_steps}.\n"
-                f"Support steps: {STEP_ORDER}"
+                f"Supported steps: {STEP_ORDER}"
             )
         return steps

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -39,18 +39,18 @@ def main(
         )
     for step_name in config.steps:
         step_dir = config.get_step_directory(step_name)
-        logger.info(f"Running step '{step_name}'")
-        runner(config.container_engine, results_dir, step_dir, step_name)
+        runner(config.container_engine, results_dir, step_name, step_dir)
 
 
 def run_container(
     container_engine: str,
     results_dir: Path,
+    step_name: str,
     step_dir: Path,
-    _step_name: str,
 ):
     # TODO: send error to stdout in the event the step script fails
     #   (currently it's only logged in the .o file)
+    logger.info(f"Running step: '{step_name}'")
     if container_engine == "docker":
         run_with_docker(results_dir, step_dir)
     elif container_engine == "singularity":
@@ -86,9 +86,10 @@ def launch_slurm_job(
     resources: Dict[str, str],
     container_engine: str,
     results_dir: Path,
-    step_dir: Path,
     step_name: str,
+    step_dir: Path,
 ) -> None:
+    logger.info(f"Launching slurm job for step '{step_name}'")
     jt = session.createJobTemplate()
     jt.jobName = f"{step_name}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     jt.joinFiles = False  # keeps stdout separate from stderr


### PR DESCRIPTION
## Title: Refactor --container-engine to specification key
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4465
- *Research reference*: <!--Link to research documentation for code --> [milestone 1.0.1.1](https://uwnetid.sharepoint.com/:w:/r/sites/ihme_simulation_science_team/_layouts/15/doc2.aspx?sourcedoc=%7B9805A749-67D7-497B-9EA8-AD8D8C879559%7D&file=Milestones.docx&action=default&mobileredirect=true)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This just moves the `--container-engine` cli option to the environment.yaml

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Manually tested.
