### PR TITLE
Feature/sbachmei/mic 4465 move container engine to config

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -76,7 +76,10 @@ def run(
 
 
 @linker.command()
-@click.argument("container_engine")
+@click.argument(
+    "container_engine",
+    type=click.Choice(["docker", "singularity", "None"]),
+)
 @click.argument(
     "results_dir",
     type=click.Path(exists=True, resolve_path=True),

--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -75,9 +75,9 @@ class Config:
         return self._load_yaml(filepath)
 
     def _get_steps(self) -> Tuple:
-        spec_steps = tuple([x for x in self.pipeline["steps"]])
+        spec_steps = tuple(self.pipeline["steps"])
         steps = tuple([x for x in spec_steps if x in STEP_ORDER])
-        unknown_steps = tuple([x for x in spec_steps if x not in STEP_ORDER])
+        unknown_steps = [x for x in spec_steps if x not in STEP_ORDER]
         if unknown_steps:
             logger.warning(
                 f"Unknown steps are included in the pipeline specification: {unknown_steps}.\n"

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -47,7 +47,7 @@ def run_container(
     results_dir: Path,
     step_name: str,
     step_dir: Path,
-):
+) -> None:
     # TODO: send error to stdout in the event the step script fails
     #   (currently it's only logged in the .o file)
     logger.info(f"Running step: '{step_name}'")

--- a/src/linker/specifications/environment.yaml
+++ b/src/linker/specifications/environment.yaml
@@ -1,4 +1,5 @@
 computing_environment: slurm
+# container_engine: singularity  # singularity or docker; comment out completely if unknown
 slurm:
   account: proj_simscience
   partition: all.q


### PR DESCRIPTION
## Title: Refactor --container-engine to specification key
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4465
- *Research reference*: <!--Link to research documentation for code --> [milestone 1.0.1.1](https://uwnetid.sharepoint.com/:w:/r/sites/ihme_simulation_science_team/_layouts/15/doc2.aspx?sourcedoc=%7B9805A749-67D7-497B-9EA8-AD8D8C879559%7D&file=Milestones.docx&action=default&mobileredirect=true)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This just moves the `--container-engine` cli option to the environment.yaml

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Manually tested.
