### PR TITLE
Make Config a ConfigTree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
         "click",
         "docker",
         "loguru",
+        "layered_config_tree",
         "pandas",
         "pyyaml",
         "pyarrow",

--- a/src/easylink/configuration.py
+++ b/src/easylink/configuration.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
-
+from easylink.utilities.data_utils import load_yaml
 from loguru import logger
 from layered_config_tree import LayeredConfigTree
 
@@ -23,23 +23,35 @@ DEFAULT_ENVIRONMENT = {
             "cpus": 1,
             "time_limit": 1,  # hours
         },
-        "spark": {
-            "workers": {
-                "num_workers": 2,
-                "cpus_per_node": 1,
-                "mem_per_node": 1,  # GB
-                "time_limit": 1,  # hours
-            },
-            "keep_alive": False,
-        },
     }
+}
+SPARK_DEFAULTS = {
+    "spark": {
+        "workers": {
+            "num_workers": 2,
+            "cpus_per_node": 1,
+            "mem_per_node": 1,  # GB
+            "time_limit": 1,  # hours
+        },
+        "keep_alive": False,
+    },
 }
 
 # Allow some buffer so that slurm doesn't kill spark workers
 SLURM_SPARK_MEM_BUFFER = 500
 
+# def build_configuration(pipeline_specification: Path, input_data: Path, computing_environment: Path, results_dir: str) -> LayeredConfigTree:
+#     """Builds the configuration tree for the pipeline."""
+#     config = LayeredConfigTree(layers=["default", "user_configured"])
+#     config.update(DEFAULT_ENVIRONMENT, layer="default")
+#     config.update(pipeline_specification, layer="user_configured", source="pipeline_spec")
+#     config.update(input_data, layer="user_configured", source="input_data_spec")
+#     config.update(computing_environment, layer="user_configured", source="computing_env_spec")
+#     config.update({"results_dir": results_dir}, layer="user_configured", source="results_dir")
+#     return config
 
-class Config:
+
+class Config(LayeredConfigTree):
     """A container for configuration information where each value is exposed
     as an attribute. This class combines the pipeline, input data, and computing
     environment specifications into a single object. It is also responsible for
@@ -48,42 +60,59 @@ class Config:
 
     def __init__(
         self,
-        pipeline_specification: Union[str, Path],
-        input_data: Union[str, Path],
-        computing_environment: Optional[Union[str, Path]],
-        results_dir: Union[str, Path],
+        pipeline_specification: Path,
+        input_data: Path,
+        computing_environment: Optional[Path],
+        results_dir: str,
     ):
-        # Handle pipeline specification
-        self.pipeline = load_yaml(pipeline_specification)
-        self._requires_spark = self._determine_if_spark_is_required(self.pipeline)
-        # Handle input data specification
-        self.input_data = self._load_input_data_paths(input_data)
-        # Handle environment specification
-        self.environment = self._load_computing_environment(computing_environment)
-        # Store path to results directory
-        self.results_dir = Path(results_dir)
+        data = {
+            "pipeline": load_yaml(pipeline_specification),
+            "input_data": self._load_input_data_paths(input_data),
+            "environment": self._load_computing_environment(computing_environment),
+            "results_dir": Path(results_dir),
+        }
+        super().__init__(layers=["initial_data", "default", "user_configured"])
+        self.update(DEFAULT_ENVIRONMENT, layer="default")
+        self.update(data, layer="user_configured")
+        for step in self.pipeline["steps"]:
+            self.update(
+                {"pipeline": {"steps" :{step: {"implementation": {"configuration": {}}}}}},
+                layer="default",
+            )
+        if self._determine_if_spark_is_required(self.pipeline):
+            self.update({"environment": SPARK_DEFAULTS}, layer="default")
+        if self.environment.computing_environment == "slurm":
+            self.update({"environment": {"slurm": {}}}, layer="default")
 
-        # Extract environment attributes and assign defaults as necessary
-        self.computing_environment = self._get_required_attribute(
-            self.environment, "computing_environment"
-        )
-        self.container_engine = self._get_required_attribute(
-            self.environment, "container_engine"
-        )
-        self.slurm = self.environment.get("slurm", {})  # no defaults for slurm
-        self.implementation_resources = self._get_implementation_resource_requests(
-            self.environment
-        )
-        self.spark = self._get_spark_requests(self.environment, self._requires_spark)
-
-        self.schema = self._get_schema()  # NOTE: must be called prior to self._validate()
+        self.update({"schema": self._get_schema()}, layer="initial_data")
         self._validate()
+
+    @property
+    def computing_environment(self):
+        return self.environment.computing_environment
+
+    @property
+    def slurm(self):
+        if not self.environment.computing_environment == "slurm":
+            return {}
+        else:
+            return self.environment.slurm.to_dict()
+
+    @property
+    def spark(self):
+        if not self._determine_if_spark_is_required(self.pipeline):
+            return {}
+        else:
+            return self.environment.spark.to_dict()
 
     @property
     def slurm_resources(self) -> Dict[str, str]:
         if not self.computing_environment == "slurm":
             return {}
-        raw_slurm_resources = {**self.slurm, **self.implementation_resources}
+        raw_slurm_resources = {
+            **self.slurm,
+            **self.environment.implementation_resources.to_dict(),
+        }
         return {
             "slurm_account": f"'{raw_slurm_resources.get('account')}'",
             "slurm_partition": f"'{raw_slurm_resources.get('partition')}'",
@@ -95,7 +124,7 @@ class Config:
     @property
     def spark_resources(self) -> Dict[str, Any]:
         """Return the spark resources as a flat dictionary"""
-        spark_workers_raw = self.spark.get("workers")
+        spark_workers_raw = self.spark["workers"]
         spark_workers = {
             "num_workers": spark_workers_raw.get("num_workers"),
             "mem_mb": int(spark_workers_raw.get("mem_per_node", 0) * 1024),
@@ -111,21 +140,21 @@ class Config:
             **{k: v for k, v in self.spark.items() if k != "workers"},
         }
 
-    def get_implementation_specific_configuration(self, step_name: str) -> Dict[str, Any]:
-        """Extracts and formats an implementation-specific configuration from the pipeline config"""
+    # def get_implementation_specific_configuration(self, step_name: str) -> Dict[str, Any]:
+    #     """Extracts and formats an implementation-specific configuration from the pipeline config"""
 
-        def _stringify_keys_values(config: Any) -> Dict[str, Any]:
-            # Singularity requires env variables be strings
-            if isinstance(config, Dict):
-                return {
-                    str(key): _stringify_keys_values(value) for key, value in config.items()
-                }
-            else:
-                # The last step of the recursion is not a dict but the leaf node's value
-                return str(config)
+    #     def _stringify_keys_values(config: Any) -> Dict[str, Any]:
+    #         # Singularity requires env variables be strings
+    #         if isinstance(config, Dict):
+    #             return {
+    #                 str(key): _stringify_keys_values(value) for key, value in config.items()
+    #             }
+    #         else:
+    #             # The last step of the recursion is not a dict but the leaf node's value
+    #             return str(config)
 
-        config = self.pipeline["steps"][step_name]["implementation"].get("configuration", {})
-        return _stringify_keys_values(config)
+    #     config = self.pipeline["steps"][step_name]["implementation"].get("configuration", {})
+    #     return _stringify_keys_values(config)
 
     def get_implementation_name(self, step_name: str) -> str:
         return self.pipeline["steps"][step_name]["implementation"]["name"]
@@ -133,9 +162,8 @@ class Config:
     #################
     # Setup Methods #
     #################
-
     @staticmethod
-    def _determine_if_spark_is_required(pipeline: Dict[str, Any]) -> bool:
+    def _determine_if_spark_is_required(pipeline) -> bool:
         """Check if the pipeline requires spark resources."""
         implementation_metadata = load_yaml(paths.IMPLEMENTATION_METADATA)
         try:
@@ -178,80 +206,6 @@ class Config:
         else:
             return load_yaml(computing_environment_specification_path)
 
-    @staticmethod
-    def _get_required_attribute(environment: Dict[Any, Any], key: str) -> str:
-        """Extracts the required-to-run (non-dict) values from the environment
-        and assigns default values if they are not present.
-        """
-        if not key in environment:
-            value = DEFAULT_ENVIRONMENT[key]
-            logger.info(f"Assigning default value for {key}: '{value}'")
-        else:
-            value = environment[key]
-        return value
-
-    @staticmethod
-    def _get_implementation_resource_requests(environment: Dict[Any, Any]) -> Dict[Any, Any]:
-        """Extracts the implementation_resources requests from the environment
-        and assigns default values if they are not present.
-        """
-        key = "implementation_resources"
-        if not key in environment:
-            # This is not strictly a required field so just return an empty dict
-            return {}
-
-        # Manually walk through the keys and assign default values if they are not present
-        requests = environment[key]
-        requests = Config._assign_defaults(key, requests, DEFAULT_ENVIRONMENT[key])
-        return requests
-
-    @staticmethod
-    def _get_spark_requests(
-        environment: Dict[Any, Any], requires_spark: bool = False
-    ) -> Dict[Any, Any]:
-        """Extracts the spark requests from the environment and assigns default
-        values if they are not present.
-        """
-        key = "spark"
-
-        if not requires_spark:
-            # This is not strictly a required field so just return an empty dict
-            return {}
-        elif not key in environment:
-            logger.info(f"Assigning default values for spark: '{DEFAULT_ENVIRONMENT[key]}'")
-            return DEFAULT_ENVIRONMENT[key]
-
-        # Manually walk through the keys and assign default values if they are not present
-        requests = environment[key]
-        # HACK: special case spark workers since it's a nested dict
-        if not "workers" in requests:
-            # Assign the entire default workers dict
-            requests["workers"] = DEFAULT_ENVIRONMENT["spark"]["workers"]
-            logger.info(
-                f"Assigning default values for spark workers: '{requests['workers']}'"
-            )
-        else:
-            # Handle workers since it's nested
-            requests["workers"] = Config._assign_defaults(
-                f"{key} workers", requests["workers"], DEFAULT_ENVIRONMENT[key]["workers"]
-            )
-        requests = Config._assign_defaults(key, requests, DEFAULT_ENVIRONMENT[key])
-
-        return requests
-
-    @staticmethod
-    def _assign_defaults(key: str, requests: Dict[str, Any], defaults: Dict[str, Any]):
-        """Loop through a single level of dictionary items and replace missing values
-        with defaults.
-        """
-        for default_key, default_value in defaults.items():
-            if not default_key in requests:
-                requests[default_key] = default_value
-                logger.info(
-                    f"Assigning default value for {key} {default_key}: '{default_value}'"
-                )
-        return requests
-
     def _get_schema(self) -> Optional[PipelineSchema]:
         """Validates the pipeline against supported schemas.
 
@@ -263,11 +217,7 @@ class Config:
         # Check that each of the pipeline steps also contains an implementation
         metadata = load_yaml(paths.IMPLEMENTATION_METADATA)
         for step, step_config in self.pipeline["steps"].items():
-            if not "implementation" in step_config:
-                errors[PIPELINE_ERRORS_KEY][
-                    f"step {step}"
-                ] = "Does not contain an 'implementation'."
-            elif not "name" in step_config["implementation"]:
+            if not "name" in step_config["implementation"]:
                 errors[PIPELINE_ERRORS_KEY][
                     f"step {step}"
                 ] = "The implementation does not contain a 'name'."
@@ -333,26 +283,15 @@ class Config:
 
     def _validate_environment(self) -> Dict[Any, Any]:
         errors = defaultdict(dict)
-        if not self.container_engine in ["docker", "singularity", "undefined"]:
+        if not self.environment.container_engine in ["docker", "singularity", "undefined"]:
             errors[ENVIRONMENT_ERRORS_KEY][
                 "container_engine"
-            ] = f"The value '{self.container_engine}' is not supported."
+            ] = f"The value '{self.environment.container_engine}' is not supported."
 
-        if self.computing_environment == "slurm" and not self.slurm:
+        if self.environment.computing_environment == "slurm" and not self.environment.slurm:
             errors[ENVIRONMENT_ERRORS_KEY]["slurm"] = (
                 "The environment configuration file must include a 'slurm' key "
                 "defining slurm resources if the computing_environment is 'slurm'."
             )
 
         return errors
-
-
-def build_configuration(pipeline_specification: Path, input_data: Path, computing_environment: Path, results_dir: str) -> LayeredConfigTree:
-    """Builds the configuration tree for the pipeline."""
-    config = LayeredConfigTree(layers=["default", "user_configured"])
-    config.update(DEFAULT_ENVIRONMENT, layer="default")
-    config.update(pipeline_specification, layer="user_configured", source="pipeline_spec")
-    config.update(input_data, layer="user_configured", source="input_data_spec")
-    config.update(computing_environment, layer="user_configured", source="computing_env_spec")
-    config.update({"results_dir": results_dir}, layer="user_configured", source="results_dir")
-    return config

--- a/src/easylink/configuration.py
+++ b/src/easylink/configuration.py
@@ -40,16 +40,6 @@ SPARK_DEFAULTS = {
 # Allow some buffer so that slurm doesn't kill spark workers
 SLURM_SPARK_MEM_BUFFER = 500
 
-# def build_configuration(pipeline_specification: Path, input_data: Path, computing_environment: Path, results_dir: str) -> LayeredConfigTree:
-#     """Builds the configuration tree for the pipeline."""
-#     config = LayeredConfigTree(layers=["default", "user_configured"])
-#     config.update(DEFAULT_ENVIRONMENT, layer="default")
-#     config.update(pipeline_specification, layer="user_configured", source="pipeline_spec")
-#     config.update(input_data, layer="user_configured", source="input_data_spec")
-#     config.update(computing_environment, layer="user_configured", source="computing_env_spec")
-#     config.update({"results_dir": results_dir}, layer="user_configured", source="results_dir")
-#     return config
-
 
 class Config(LayeredConfigTree):
     """A container for configuration information where each value is exposed

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -18,7 +18,9 @@ class Implementation:
         self.config = config
         self._pipeline_step_name = step.name
         self.name = config.get_implementation_name(step.name)
-        self.environment_variables = config.pipeline["steps"][self.step.name]["implementation"]["configuration"]
+        self.environment_variables = config.pipeline["steps"][self.step.name][
+            "implementation"
+        ]["configuration"]
         self._metadata = self._load_metadata()
         self.step_name = self._metadata["step"]
         self.requires_spark = self._metadata.get("requires_spark", False)

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -20,7 +20,7 @@ class Implementation:
         self.name = config.get_implementation_name(step.name)
         self.environment_variables = config.pipeline["steps"][self.step.name][
             "implementation"
-        ]["configuration"]
+        ]["configuration"].to_dict()
         self._metadata = self._load_metadata()
         self.step_name = self._metadata["step"]
         self.requires_spark = self._metadata.get("requires_spark", False)

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -18,9 +18,7 @@ class Implementation:
         self.config = config
         self._pipeline_step_name = step.name
         self.name = config.get_implementation_name(step.name)
-        self.environment_variables = config.pipeline["steps"][self.step.name][
-            "implementation"
-        ].get("configuration", {})
+        self.environment_variables = config.pipeline["steps"][self.step.name]["implementation"]["configuration"]
         self._metadata = self._load_metadata()
         self.step_name = self._metadata["step"]
         self.requires_spark = self._metadata.get("requires_spark", False)

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -18,9 +18,9 @@ class Implementation:
         self.config = config
         self._pipeline_step_name = step.name
         self.name = config.get_implementation_name(step.name)
-        self.environment_variables = config.pipeline["steps"][self.step.name][
-            "implementation"
-        ]["configuration"].to_dict()
+        self.environment_variables = config.pipeline[self.step.name]["implementation"][
+            "configuration"
+        ].to_dict()
         self._metadata = self._load_metadata()
         self.step_name = self._metadata["step"]
         self.requires_spark = self._metadata.get("requires_spark", False)

--- a/src/easylink/runner.py
+++ b/src/easylink/runner.py
@@ -6,7 +6,7 @@ from typing import List
 from loguru import logger
 from snakemake.cli import main as snake_main
 
-from easylink.configuration import Config
+from easylink.configuration import Config, load_params_from_specification
 from easylink.pipeline import Pipeline
 from easylink.utilities.data_utils import copy_configuration_files_to_results_directory
 from easylink.utilities.general_utils import is_on_slurm
@@ -21,13 +21,10 @@ def main(
     debug=False,
 ) -> None:
     """Set up and run the pipeline"""
-
-    config = Config(
-        pipeline_specification=pipeline_specification,
-        input_data=input_data,
-        computing_environment=computing_environment,
-        results_dir=results_dir,
+    config_params = load_params_from_specification(
+        pipeline_specification, input_data, computing_environment, results_dir
     )
+    config = Config(config_params)
     pipeline = Pipeline(config)
     # Now that all validation is done, create results dir and copy the configuration files to the results directory
     copy_configuration_files_to_results_directory(

--- a/tests/specifications/e2e/pipeline.yaml
+++ b/tests/specifications/e2e/pipeline.yaml
@@ -1,19 +1,18 @@
-steps:
-  step_1:
-    implementation:
-      name: step_1_python_pandas
-  step_2:
-    implementation:
-      name: step_2_python_pyspark_distributed
-      configuration:
-        DUMMY_CONTAINER_INCREMENT: 100
-  step_3:
-    implementation:
-      name: step_3_python_pandas
-      configuration:
-        DUMMY_CONTAINER_INCREMENT: 702
-  step_4:
-    implementation:
-      name: step_4_r
-      configuration:
-        DUMMY_CONTAINER_INCREMENT: 912
+step_1:
+  implementation:
+    name: step_1_python_pandas
+step_2:
+  implementation:
+    name: step_2_python_pyspark_distributed
+    configuration:
+      DUMMY_CONTAINER_INCREMENT: 100
+step_3:
+  implementation:
+    name: step_3_python_pandas
+    configuration:
+      DUMMY_CONTAINER_INCREMENT: 702
+step_4:
+  implementation:
+    name: step_4_r
+    configuration:
+      DUMMY_CONTAINER_INCREMENT: 912

--- a/tests/specifications/integration/pipeline.yaml
+++ b/tests/specifications/integration/pipeline.yaml
@@ -1,4 +1,3 @@
-steps:
-  step_1:
-    implementation:
-     name: step_1_python_pandas
+step_1:
+  implementation:
+    name: step_1_python_pandas

--- a/tests/specifications/integration/pipeline_spark.yaml
+++ b/tests/specifications/integration/pipeline_spark.yaml
@@ -1,4 +1,3 @@
-steps:
-  step_1:
-    implementation:
-     name: step_1_python_pyspark_distributed
+step_1:
+  implementation:
+    name: step_1_python_pyspark_distributed

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -106,6 +106,11 @@ PIPELINE_CONFIG_DICT = {
             },
         },
     },
+    "missing_implementations": {
+        "step_1": {
+            "foo": "bar",  # Missing implementation key
+        },
+    },
     "missing_implementation_name": {
         "step_1": {
             "implementation": {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import pytest
 import yaml
 
-from easylink.configuration import Config
+from easylink.configuration import Config, load_params_from_specification
 
 ENV_CONFIG_DICT = {
     "minimum": {
@@ -156,22 +156,6 @@ def test_dir(tmpdir_factory) -> str:
     # good pipeline.yaml
     with open(f"{str(tmp_path)}/pipeline.yaml", "w") as file:
         yaml.dump(PIPELINE_CONFIG_DICT["good"], file, sort_keys=False)
-        # good pipeline.yaml
-    with open(f"{str(tmp_path)}/pipeline_spark.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["spark"], file, sort_keys=False)
-    # bad pipeline.yamls
-    with open(f"{str(tmp_path)}/out_of_order_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["out_of_order"], file, sort_keys=False)
-    with open(f"{str(tmp_path)}/missing_step_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["missing_step"], file, sort_keys=False)
-    with open(f"{str(tmp_path)}/bad_step_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["bad_step"], file, sort_keys=False)
-    with open(f"{str(tmp_path)}/missing_outer_key_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["good"]["steps"], file, sort_keys=False)
-    with open(f"{str(tmp_path)}/missing_implementation_name_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["missing_implementation_name"], file, sort_keys=False)
-    with open(f"{str(tmp_path)}/bad_implementation_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["bad_implementation"], file, sort_keys=False)
 
     # dummy environment.yaml
     with open(f"{str(tmp_path)}/environment.yaml", "w") as file:
@@ -274,7 +258,7 @@ def results_dir(test_dir) -> Path:
 
 
 @pytest.fixture()
-def default_config_params(test_dir, results_dir) -> Dict[str, Path]:
+def default_config_paths(test_dir, results_dir) -> Dict[str, Path]:
     return {
         "pipeline_specification": Path(f"{test_dir}/pipeline.yaml"),
         "input_data": Path(f"{test_dir}/input_data.yaml"),
@@ -284,6 +268,11 @@ def default_config_params(test_dir, results_dir) -> Dict[str, Path]:
 
 
 @pytest.fixture()
+def default_config_params(default_config_paths) -> Dict[str, Path]:
+    return load_params_from_specification(**default_config_paths)
+
+
+@pytest.fixture()
 def default_config(default_config_params) -> Config:
     """A good/known Config object"""
-    return Config(**default_config_params)
+    return Config(default_config_params)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,100 +37,86 @@ ENV_CONFIG_DICT = {
 
 PIPELINE_CONFIG_DICT = {
     "good": {
-        "steps": {
-            "step_1": {
-                "implementation": {
-                    "name": "step_1_python_pandas",
-                },
+        "step_1": {
+            "implementation": {
+                "name": "step_1_python_pandas",
             },
-            "step_2": {
-                "implementation": {
-                    "name": "step_2_python_pandas",
-                },
+        },
+        "step_2": {
+            "implementation": {
+                "name": "step_2_python_pandas",
             },
-            "step_3": {
-                "implementation": {
-                    "name": "step_3_python_pandas",
-                },
+        },
+        "step_3": {
+            "implementation": {
+                "name": "step_3_python_pandas",
             },
-            "step_4": {
-                "implementation": {
-                    "name": "step_4_python_pandas",
-                },
+        },
+        "step_4": {
+            "implementation": {
+                "name": "step_4_python_pandas",
             },
         },
     },
     "spark": {
-        "steps": {
-            "step_1": {
-                "implementation": {
-                    "name": "step_1_python_pyspark_distributed",
-                },
+        "step_1": {
+            "implementation": {
+                "name": "step_1_python_pyspark_distributed",
             },
-            "step_2": {
-                "implementation": {
-                    "name": "step_2_python_pyspark_distributed",
-                },
+        },
+        "step_2": {
+            "implementation": {
+                "name": "step_2_python_pyspark_distributed",
             },
         },
     },
     "out_of_order": {
-        "steps": {
-            "step_2": {
-                "implementation": {
-                    "name": "step_2_python_pandas",
-                },
+        "step_2": {
+            "implementation": {
+                "name": "step_2_python_pandas",
             },
-            "step_1": {
-                "implementation": {
-                    "name": "step_1_python_pandas",
-                },
+        },
+        "step_1": {
+            "implementation": {
+                "name": "step_1_python_pandas",
             },
-            "step_3": {
-                "implementation": {
-                    "name": "step_3_python_pandas",
-                },
+        },
+        "step_3": {
+            "implementation": {
+                "name": "step_3_python_pandas",
             },
-            "step_4": {
-                "implementation": {
-                    "name": "step_4_python_pandas",
-                },
+        },
+        "step_4": {
+            "implementation": {
+                "name": "step_4_python_pandas",
             },
         },
     },
     "missing_step": {
-        "steps": {
-            "step_2": {
-                "implementation": {
-                    "name": "step_2_python_pandas",
-                },
+        "step_2": {
+            "implementation": {
+                "name": "step_2_python_pandas",
             },
         },
     },
     "bad_step": {
-        "steps": {
-            "foo": {  # Not a supported step
-                "implementation": {
-                    "name": "step_1_python_pandas",
-                },
+        "foo": {  # Not a supported step
+            "implementation": {
+                "name": "step_1_python_pandas",
             },
         },
     },
     "missing_implementation_name": {
-        "steps": {
-            "step_1": {
-                "implementation": {
-                    "foo": "bar",  # Missing name key
-                },
+        "step_1": {
+            "implementation": {
+                "foo": "bar",  # Missing name key
             },
         },
     },
     "bad_implementation": {
-        "steps": {
-            "step_1": {
-                "implementation": {
-                    "name": "foo",  # Not a supported implementation
-                },
+        "step_1": {
+            "implementation": {
+                "name": "foo",  # Not a supported implementation
             },
         },
     },

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -116,13 +116,6 @@ PIPELINE_CONFIG_DICT = {
             },
         },
     },
-    "missing_implementations": {
-        "steps": {
-            "step_1": {
-                "foo": "bar",  # Missing implementation key
-            },
-        },
-    },
     "missing_implementation_name": {
         "steps": {
             "step_1": {
@@ -175,8 +168,6 @@ def test_dir(tmpdir_factory) -> str:
         yaml.dump(PIPELINE_CONFIG_DICT["bad_step"], file, sort_keys=False)
     with open(f"{str(tmp_path)}/missing_outer_key_pipeline.yaml", "w") as file:
         yaml.dump(PIPELINE_CONFIG_DICT["good"]["steps"], file, sort_keys=False)
-    with open(f"{str(tmp_path)}/missing_implementation_pipeline.yaml", "w") as file:
-        yaml.dump(PIPELINE_CONFIG_DICT["missing_implementations"], file, sort_keys=False)
     with open(f"{str(tmp_path)}/missing_implementation_name_pipeline.yaml", "w") as file:
         yaml.dump(PIPELINE_CONFIG_DICT["missing_implementation_name"], file, sort_keys=False)
     with open(f"{str(tmp_path)}/bad_implementation_pipeline.yaml", "w") as file:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -42,7 +42,7 @@ def test__load_input_data_paths(test_dir):
             "environment.yaml",
             {
                 k: v
-                for k, v in DEFAULT_ENVIRONMENT.items()
+                for k, v in DEFAULT_ENVIRONMENT["environment"].items()
                 if k in ["computing_environment", "container_engine"]
             },
         ),
@@ -91,26 +91,6 @@ def test_environment_configuration_not_found(default_config_params, computing_en
     )
     with pytest.raises(FileNotFoundError):
         Config(**config_params)
-
-
-@pytest.mark.parametrize(
-    "key, input",
-    [
-        ("computing_environment", None),
-        ("computing_environment", "local"),
-        ("computing_environment", "slurm"),
-        ("container_engine", None),
-        ("container_engine", "docker"),
-        ("container_engine", "singularity"),
-        ("container_engine", "undefined"),
-    ],
-)
-def test__get_required_attribute(key, input):
-    env_dict = {key: input} if input else {}
-    retrieved = Config._get_required_attribute(env_dict, key)
-    expected = DEFAULT_ENVIRONMENT.copy()
-    expected.update(env_dict)
-    assert retrieved == expected[key]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -195,6 +195,9 @@ def test_spark_requests(default_config_params, input, requires_spark):
     retrieved = Config(config_params).environment[key].to_dict()
     expected_env_dict = {key: input.copy()} if input else {}
     if requires_spark:
+        # It's tricky to get the exact right behavior here without appealing to configtree
+        # "workers" is a nested dictionary, so the normal dict update method doesn't work
+        # for a partially specified environment here
         expected = LayeredConfigTree(SPARK_DEFAULTS, layers=["initial_data", "user"])
         if input:
             expected.update(expected_env_dict[key], layer="user")

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -9,14 +9,14 @@ from easylink.utilities.data_utils import (
 )
 
 
-def test_copy_configuration_files_to_results_directory(default_config_params, test_dir):
+def test_copy_configuration_files_to_results_directory(default_config_paths, test_dir):
     output_dir = Path(test_dir + "/some/output/dir")
-    config_params = default_config_params
-    config_params["results_dir"] = output_dir
+    config_paths = default_config_paths
+    config_paths["results_dir"] = output_dir
     copy_configuration_files_to_results_directory(
-        config_params["pipeline_specification"],
-        config_params["input_data"],
-        config_params["computing_environment"],
+        config_paths["pipeline_specification"],
+        config_paths["input_data"],
+        config_paths["computing_environment"],
         output_dir,
     )
     assert output_dir.exists()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -7,11 +7,12 @@ import pytest
 from easylink.configuration import Config
 from easylink.runner import get_environment_args, get_singularity_args
 from easylink.utilities.paths import EASYLINK_TEMP
+from tests.unit.conftest import ENV_CONFIG_DICT
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
-def test_get_singularity_args(default_config, test_dir, results_dir):
+def test_get_singularity_args(default_config, test_dir):
     assert (
         get_singularity_args(default_config)
         == f"--no-home --containall -B {EASYLINK_TEMP[default_config.computing_environment]}:/tmp,"
@@ -23,7 +24,7 @@ def test_get_singularity_args(default_config, test_dir, results_dir):
 
 
 def test_get_environment_args_local(default_config_params):
-    config = Config(**default_config_params)
+    config = Config(default_config_params)
     assert get_environment_args(config) == []
 
 
@@ -31,10 +32,10 @@ def test_get_environment_args_local(default_config_params):
     IN_GITHUB_ACTIONS,
     reason="Github Actions does not have access to our file system and so no SLURM.",
 )
-def test_get_environment_args_slurm(default_config_params, test_dir):
+def test_get_environment_args_slurm(default_config_params):
     slurm_config_params = default_config_params
-    slurm_config_params["computing_environment"] = Path(f"{test_dir}/spark_environment.yaml")
-    slurm_config = Config(**slurm_config_params)
+    slurm_config_params["environment"] = ENV_CONFIG_DICT["with_spark_and_slurm"]
+    slurm_config = Config(slurm_config_params)
     resources = slurm_config.slurm_resources
     assert get_environment_args(slurm_config) == [
         "--executor",

--- a/tests/unit/test_validations.py
+++ b/tests/unit/test_validations.py
@@ -62,15 +62,6 @@ def test_batch_validation():
 @pytest.mark.parametrize(
     "pipeline, expected_msg",
     [
-        # missing 'implementation' key
-        (
-            "missing_implementation_pipeline.yaml",
-            {
-                PIPELINE_ERRORS_KEY: {
-                    "step step_1": ["Does not contain an 'implementation'."]
-                },
-            },
-        ),
         # missing implementation 'name' key
         (
             "missing_implementation_name_pipeline.yaml",
@@ -280,13 +271,10 @@ def test_pipeline_schema_missing_input_file(default_config_params, test_dir, cap
 def test_unsupported_container_engine(default_config_params, caplog, mocker):
     config_params = default_config_params
     config_params["computing_environment"] = None
-
     mocker.patch(
-        "easylink.configuration.Config._get_required_attribute",
-        side_effect=lambda _env, attribute: (
-            "foo" if attribute == "container_engine" else None
-        ),
-    )
+        "easylink.configuration.Config._load_computing_environment",
+        return_value={"container_engine": "foo"})
+
     with pytest.raises(SystemExit) as e:
         Config(**config_params)
     _check_expected_validation_exit(
@@ -303,11 +291,8 @@ def test_unsupported_container_engine(default_config_params, caplog, mocker):
 
 def test_missing_slurm_details(default_config_params, caplog, mocker):
     mocker.patch(
-        "easylink.configuration.Config._get_required_attribute",
-        side_effect=lambda _env, attribute: (
-            "slurm" if attribute == "computing_environment" else "undefined"
-        ),
-    )
+        "easylink.configuration.Config._load_computing_environment",
+        return_value={"computing_environment": "slurm"})
     config_params = default_config_params
     config_params["computing_environment"] = None
     with pytest.raises(SystemExit) as e:

--- a/tests/unit/test_validations.py
+++ b/tests/unit/test_validations.py
@@ -115,9 +115,7 @@ def test_batch_validation():
     ],
 )
 def test_pipeline_validation(pipeline, default_config_params, expected_msg, caplog, mocker):
-    mocker.patch(
-        "easylink.configuration.Config._determine_if_spark_is_required", return_value=False
-    )
+    mocker.patch("easylink.configuration.Config._spark_is_required", return_value=False)
     config_params = default_config_params
     config_params["pipeline"] = PIPELINE_CONFIG_DICT[pipeline]
 
@@ -165,9 +163,7 @@ def test_unsupported_step(default_config_params, caplog, mocker):
 def test_unsupported_implementation(default_config_params, caplog, mocker):
     mocker.patch("easylink.implementation.Implementation._load_metadata")
     mocker.patch("easylink.implementation.Implementation.validate", return_value=[])
-    mocker.patch(
-        "easylink.configuration.Config._determine_if_spark_is_required", return_value=False
-    )
+    mocker.patch("easylink.configuration.Config._spark_is_required", return_value=False)
     config_params = default_config_params
     config_params["pipeline"] = PIPELINE_CONFIG_DICT["bad_implementation"]
 

--- a/tests/unit/test_validations.py
+++ b/tests/unit/test_validations.py
@@ -64,6 +64,15 @@ def test_batch_validation():
 @pytest.mark.parametrize(
     "pipeline, expected_msg",
     [
+        # missing 'implementation' key
+        (
+            "missing_implementations",
+            {
+                PIPELINE_ERRORS_KEY: {
+                    "step step_1": ["The implementation does not contain a 'name'."]
+                },
+            },
+        ),
         # missing implementation 'name' key
         (
             "missing_implementation_name",


### PR DESCRIPTION
## Make Config a ConfigTree
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4883
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I made the Configuration object a LayeredConfigTree so that setting the defaults was easier.

I also did a few related refactors--
The nature of layeredconfigtree is such that we no longer have a number of private methods that go about setting defaults and configuring various parts of the user-defined specs (spark for example). This means that we have to create the whole Config object to test them now. Additionally, many of the tests rely on dictionaries that get written to a temporary directory which are then read in to create the config. I thought it would be a bit nicer to separate the loading / basic parsing of the yamls from Config, (their errors are already raised independently of the validations) so we can just test whether that reads yamls correctly and then test everything else using the original dictionaries.

This allows us avoid writing a lot of temporary yamls.

There may be a few things I'm doing sub-optimally with the ConfigTree, syntactically speaking.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
All tests pass, including some refactored tests.
