### PR TITLE
Change placement of step keys

### DIFF
--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -25,6 +25,10 @@ class PipelineSchema(CompositeStep):
         return graph
 
     @property
+    def step_key(self) -> str:
+        return None
+
+    @property
     def step_nodes(self) -> List[str]:
         """Return list of nodes tied to specific implementations."""
         ordered_nodes = list(nx.topological_sort(self.graph))

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -25,10 +25,6 @@ class PipelineSchema(CompositeStep):
         return graph
 
     @property
-    def step_key(self) -> str:
-        return None
-
-    @property
     def step_nodes(self) -> List[str]:
         """Return list of nodes tied to specific implementations."""
         ordered_nodes = list(nx.topological_sort(self.graph))

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -179,9 +179,7 @@ class CompositeStep(Step):
         self.remap_slots(graph, step_config)
         for node in self.graph.nodes:
             step = self.graph.nodes[node]["step"]
-            sub_config = step_config
-            if not isinstance(step, IOStep):
-                sub_config = step_config[step.name]
+            sub_config = step_config if isinstance(step, IOStep) else step_config[step.name]
             step.update_implementation_graph(graph, sub_config)
             graph.remove_node(node)
 

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -285,7 +285,7 @@ def test_hierarchical_step_update_implementation_graph(
 ) -> None:
     step = HierarchicalStep(**hierarchical_step_params)
     pipeline_params = LayeredConfigTree(
-        {"step_1": {"implementation": {"name": "step_1_python_pandas", "configuration": {}}}}
+        {"implementation": {"name": "step_1_python_pandas", "configuration": {}}}
     )
     subgraph = nx.MultiDiGraph()
     step.update_implementation_graph(subgraph, pipeline_params)
@@ -295,23 +295,21 @@ def test_hierarchical_step_update_implementation_graph(
     # Test update_implementation_graph for substeps
     pipeline_params = LayeredConfigTree(
         {
-            "step_1": {
-                "substeps": {
-                    "step_1a": {
-                        "implementation": {
-                            "name": "step_1a_python_pandas",
-                            "configuration": {},
-                        }
-                    },
-                    "step_1b": {
-                        "implementation": {
-                            "name": "step_1b_python_pandas",
-                            "configuration": {},
-                        }
-                    },
+            "substeps": {
+                "step_1a": {
+                    "implementation": {
+                        "name": "step_1a_python_pandas",
+                        "configuration": {},
+                    }
+                },
+                "step_1b": {
+                    "implementation": {
+                        "name": "step_1b_python_pandas",
+                        "configuration": {},
+                    }
                 },
             },
-        }
+        },
     )
     subgraph = nx.MultiDiGraph(
         [

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -48,7 +48,7 @@ def test_implemented_step(default_config: Config) -> None:
 
     # Test update_implementation_graph
     subgraph = nx.MultiDiGraph()
-    step.update_implementation_graph(subgraph, default_config["pipeline"])
+    step.update_implementation_graph(subgraph, default_config["pipeline"][step.name])
     assert list(subgraph.nodes) == ["step_1_python_pandas"]
     assert list(subgraph.edges) == []
 


### PR DESCRIPTION
## Change placement of step keys
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I didn't like how each step takes the config *above* itself and determines how to subselect it within all of its methods. I think it makes more sense to just ensure that CompositeSteps reduce the scope of the config appropriately to each step depending on what sort of key they're supposed to have (usually the step name, but sometimes nothing)

This is a matter of taste i guess, so LMK if you have the opposite opinion.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tests pass
