### PR TITLE
remove method to fill configuration defaults

### DIFF
--- a/src/easylink/configuration.py
+++ b/src/easylink/configuration.py
@@ -103,7 +103,6 @@ class Config(LayeredConfigTree):
 
         self.update({"schema": self._get_schema()}, layer="initial_data")
         self._validate()
-        self.update_implementation_configs(self.pipeline)
         self.freeze()
 
     @property
@@ -163,17 +162,6 @@ class Config(LayeredConfigTree):
     #################
     # Setup Methods #
     #################
-    def update_implementation_configs(self, level: LayeredConfigTree):
-        """Recursively add empty configuration dictionaries to each implementation configuration.
-        'Level' should be set such that its keys are steps (which may have implementations).
-        """
-        for step in level.values():
-            if "implementation" in step:
-                step.implementation.update({"configuration": {}}, layer="default")
-
-            elif "substeps" in step:
-                self.update_implementation_configs(step.substeps)
-
     def _get_schema(self) -> Optional[PipelineSchema]:
         """Validates the pipeline against supported schemas.
 

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from layered_config_tree import LayeredConfigTree
+
 from easylink.utilities import paths
 from easylink.utilities.data_utils import load_yaml
 
@@ -13,9 +15,9 @@ class Implementation:
     inside the container, and some metadata about the container.
     """
 
-    def __init__(self, name: str, step_name: str, environment_variables: Dict[str, str]):
-        self.name = name
-        self.environment_variables = environment_variables
+    def __init__(self, step_name: str, implementation_config: LayeredConfigTree):
+        self.name = implementation_config.name
+        self.environment_variables = implementation_config.to_dict().get("configuration", {})
         self._metadata = self._load_metadata()
         self.metadata_step_name = self._metadata["step"]
         self.schema_step_name = step_name

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -85,15 +85,12 @@ class BasicStep(Step):
         self, graph: nx.MultiDiGraph, step_config: LayeredConfigTree
     ) -> None:
         """Return a single node with an implementation attribute."""
-        implementation_name = step_config["implementation"]["name"]
-        implementation_config = step_config["implementation"]["configuration"]
         implementation = Implementation(
-            name=implementation_name,
             step_name=self.name,
-            environment_variables=implementation_config.to_dict(),
+            implementation_config=step_config["implementation"],
         )
         graph.add_node(
-            implementation_name,
+            step_config["implementation"]["name"],
             implementation=implementation,
         )
         self.update_edges(graph, step_config)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -192,21 +192,3 @@ def test_spark_requests(default_config_params, input, requires_spark):
         expected.update(expected_env_dict[key], layer="user")
     expected = expected.to_dict()
     assert retrieved == expected
-
-
-@pytest.mark.parametrize("includes_implementation_configuration", [False, True])
-def test_get_implementation_specific_configuration(
-    default_config_params, includes_implementation_configuration
-):
-    config_params = default_config_params
-    step_1_config = {}
-    step_2_config = {}
-    if includes_implementation_configuration:
-        step_2_config = {
-            "SOME-CONFIGURATION": "some-value",
-            "SOME-OTHER-CONFIGURATION": "some-other-value",
-        }
-        config_params["pipeline"]["step_2"]["implementation"]["configuration"] = step_2_config
-    config = Config(config_params)
-    assert config.pipeline.step_1.implementation.configuration.to_dict() == step_1_config
-    assert config.pipeline.step_2.implementation.configuration.to_dict() == step_2_config


### PR DESCRIPTION
## Remove method to fill configuration defaults
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
@zmbc pointed out that instead of extending the method used to fill implementation configurations, it would be better to just handle this (optional) configuration key when the configuration is parsed by the Implementation.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tests pass
