### PR TITLE
Add DAG visualization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     install_requirements = [
         "click",
         "docker",
+        "graphviz",
         "loguru",
         "layered_config_tree",
         "networkx",

--- a/src/easylink/cli.py
+++ b/src/easylink/cli.py
@@ -40,25 +40,7 @@ SHARED_OPTIONS = [
         default=True,
         show_default=True,
         help="Save the results in a timestamped sub-directory of --output-dir.",
-    ),
-    click.option(
-        "-e",
-        "--computing-environment",
-        default=None,
-        show_default=True,
-        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-        help=("Path to a computing environment yaml file on which to launch the step."),
-    ),
-    click.option(
-        "-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True
-    ),
-    click.option(
-        "--pdb",
-        "with_debugger",
-        is_flag=True,
-        help="Drop into python debugger if an error occurs.",
-        hidden=True,
-    ),
+    )
 ]
 
 
@@ -79,6 +61,24 @@ def easylink():
 
 @easylink.command()
 @pass_shared_options
+@click.option(
+        "-e",
+        "--computing-environment",
+        default=None,
+        show_default=True,
+        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+        help=("Path to a computing environment yaml file on which to launch the step."),
+    )
+@click.option(
+        "-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True
+    )
+@click.option(
+        "--pdb",
+        "with_debugger",
+        is_flag=True,
+        help="Drop into python debugger if an error occurs.",
+        hidden=True,
+    )
 def run(
     pipeline_specification: str,
     input_data: str,
@@ -115,25 +115,17 @@ def generate_dag(
     input_data: str,
     output_dir: Optional[str],
     timestamp: bool,
-    computing_environment: Optional[str],
-    verbose: int,
-    with_debugger: bool,
 ) -> None:
     """Generate a DAG file from the command line."""
-    configure_logging_to_terminal(verbose)
     logger.info("Generating DAG")
     results_dir = get_results_directory(output_dir, timestamp).as_posix()
     logger.info(f"Results directory: {results_dir}")
     # TODO [MIC-4493]: Add configuration validation
-
-    main = handle_exceptions(
-        func=runner.main, exceptions_logger=logger, with_debugger=with_debugger
-    )
-    main(
+    runner.main(
         command="generate_dag",
         pipeline_specification=pipeline_specification,
         input_data=input_data,
-        computing_environment=computing_environment,
+        computing_environment=None,
         results_dir=results_dir,
     )
     logger.info("*** DAG saved to result directory ***")

--- a/src/easylink/cli.py
+++ b/src/easylink/cli.py
@@ -40,7 +40,7 @@ SHARED_OPTIONS = [
         default=True,
         show_default=True,
         help="Save the results in a timestamped sub-directory of --output-dir.",
-    )
+    ),
 ]
 
 
@@ -62,23 +62,21 @@ def easylink():
 @easylink.command()
 @pass_shared_options
 @click.option(
-        "-e",
-        "--computing-environment",
-        default=None,
-        show_default=True,
-        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-        help=("Path to a computing environment yaml file on which to launch the step."),
-    )
+    "-e",
+    "--computing-environment",
+    default=None,
+    show_default=True,
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    help=("Path to a computing environment yaml file on which to launch the step."),
+)
+@click.option("-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True)
 @click.option(
-        "-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True
-    )
-@click.option(
-        "--pdb",
-        "with_debugger",
-        is_flag=True,
-        help="Drop into python debugger if an error occurs.",
-        hidden=True,
-    )
+    "--pdb",
+    "with_debugger",
+    is_flag=True,
+    help="Drop into python debugger if an error occurs.",
+    hidden=True,
+)
 def run(
     pipeline_specification: str,
     input_data: str,

--- a/src/easylink/cli.py
+++ b/src/easylink/cli.py
@@ -10,6 +10,63 @@ from easylink.utilities.general_utils import (
     handle_exceptions,
 )
 
+SHARED_OPTIONS = [
+    click.option(
+        "-p",
+        "--pipeline-specification",
+        required=True,
+        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+        help="The path to the pipeline specification yaml file.",
+    ),
+    click.option(
+        "-i",
+        "--input-data",
+        required=True,
+        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+        help="The path to the input data specification yaml file (not the paths to the input data themselves).",
+    ),
+    click.option(
+        "-o",
+        "--output-dir",
+        type=click.Path(exists=False, dir_okay=True, resolve_path=True),
+        help=(
+            "The directory to write results and incidental files (logs, etc.) to. "
+            "If no value is passed, results will be written to a 'results/' directory "
+            "in the current working directory."
+        ),
+    ),
+    click.option(
+        "--timestamp/--no-timestamp",
+        default=True,
+        show_default=True,
+        help="Save the results in a timestamped sub-directory of --output-dir.",
+    ),
+    click.option(
+        "-e",
+        "--computing-environment",
+        default=None,
+        show_default=True,
+        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+        help=("Path to a computing environment yaml file on which to launch the step."),
+    ),
+    click.option(
+        "-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True
+    ),
+    click.option(
+        "--pdb",
+        "with_debugger",
+        is_flag=True,
+        help="Drop into python debugger if an error occurs.",
+        hidden=True,
+    ),
+]
+
+
+def pass_shared_options(func):
+    for option in SHARED_OPTIONS:
+        func = option(func)
+    return func
+
 
 @click.group()
 def easylink():
@@ -21,52 +78,7 @@ def easylink():
 
 
 @easylink.command()
-@click.option(
-    "-p",
-    "--pipeline-specification",
-    required=True,
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    help="The path to the pipeline specification yaml file.",
-)
-@click.option(
-    "-i",
-    "--input-data",
-    required=True,
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    help="The path to the input data specification yaml file (not the paths to the input data themselves).",
-)
-@click.option(
-    "-o",
-    "--output-dir",
-    type=click.Path(exists=False, dir_okay=True, resolve_path=True),
-    help=(
-        "The directory to write results and incidental files (logs, etc.) to. "
-        "If no value is passed, results will be written to a 'results/' directory "
-        "in the current working directory."
-    ),
-)
-@click.option(
-    "--timestamp/--no-timestamp",
-    default=True,
-    show_default=True,
-    help="Save the results in a timestamped sub-directory of --output-dir.",
-)
-@click.option(
-    "-e",
-    "--computing-environment",
-    default=None,
-    show_default=True,
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    help=("Path to a computing environment yaml file on which to launch the step."),
-)
-@click.option("-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True)
-@click.option(
-    "--pdb",
-    "with_debugger",
-    is_flag=True,
-    help="Drop into python debugger if an error occurs.",
-    hidden=True,
-)
+@pass_shared_options
 def run(
     pipeline_specification: str,
     input_data: str,
@@ -87,9 +99,41 @@ def run(
         func=runner.main, exceptions_logger=logger, with_debugger=with_debugger
     )
     main(
+        command="run",
         pipeline_specification=pipeline_specification,
         input_data=input_data,
         computing_environment=computing_environment,
         results_dir=results_dir,
     )
     logger.info("*** FINISHED ***")
+
+
+@easylink.command()
+@pass_shared_options
+def generate_dag(
+    pipeline_specification: str,
+    input_data: str,
+    output_dir: Optional[str],
+    timestamp: bool,
+    computing_environment: Optional[str],
+    verbose: int,
+    with_debugger: bool,
+) -> None:
+    """Generate a DAG file from the command line."""
+    configure_logging_to_terminal(verbose)
+    logger.info("Generating DAG")
+    results_dir = get_results_directory(output_dir, timestamp).as_posix()
+    logger.info(f"Results directory: {results_dir}")
+    # TODO [MIC-4493]: Add configuration validation
+
+    main = handle_exceptions(
+        func=runner.main, exceptions_logger=logger, with_debugger=with_debugger
+    )
+    main(
+        command="generate_dag",
+        pipeline_specification=pipeline_specification,
+        input_data=input_data,
+        computing_environment=computing_environment,
+        results_dir=results_dir,
+    )
+    logger.info("*** DAG saved to result directory ***")

--- a/src/easylink/runner.py
+++ b/src/easylink/runner.py
@@ -1,10 +1,10 @@
 import os
 import socket
 import subprocess
-from graphviz import Source
 from pathlib import Path
 from typing import List
 
+from graphviz import Source
 from loguru import logger
 from snakemake.cli import main as snake_main
 

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -5,23 +5,20 @@ import pytest
 
 from easylink.utilities.data_utils import (
     copy_configuration_files_to_results_directory,
+    create_results_directory,
+    create_results_intermediates,
     get_results_directory,
 )
 
 
-def test_copy_configuration_files_to_results_directory(default_config_paths, test_dir):
-    output_dir = Path(test_dir + "/some/output/dir")
-    config_paths = default_config_paths
-    config_paths["results_dir"] = output_dir
-    copy_configuration_files_to_results_directory(
-        config_paths["pipeline_specification"],
-        config_paths["input_data"],
-        config_paths["computing_environment"],
-        output_dir,
-    )
-    assert output_dir.exists()
-    assert (output_dir / "intermediate").exists()
-    assert (output_dir / "diagnostics").exists()
+def test_create_results_directory(test_dir):
+    results_dir = Path(test_dir + "/some/output/dir")
+    create_results_directory(results_dir)
+    assert results_dir.exists()
+
+    create_results_intermediates(results_dir)
+    assert (results_dir / "intermediate").exists()
+    assert (results_dir / "diagnostics").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -5,7 +5,11 @@ import pytest
 
 from easylink.configuration import Config, load_params_from_specification
 from easylink.pipeline import Pipeline
-from easylink.utilities.data_utils import copy_configuration_files_to_results_directory
+from easylink.utilities.data_utils import (
+    copy_configuration_files_to_results_directory,
+    create_results_directory,
+    create_results_intermediates,
+)
 
 PIPELINE_STRINGS = {
     "local": "rule_strings/pipeline_local.txt",
@@ -14,7 +18,9 @@ PIPELINE_STRINGS = {
 
 
 @pytest.mark.parametrize("computing_environment", ["local", "slurm"])
-def test_build_snakefile(default_config_paths, mocker, test_dir, computing_environment):
+def test_build_snakefile(
+    default_config_paths, mocker, test_dir, results_dir, computing_environment
+):
     config_paths = default_config_paths
     if computing_environment == "slurm":
         config_paths["computing_environment"] = f"{test_dir}/spark_environment.yaml"
@@ -23,6 +29,8 @@ def test_build_snakefile(default_config_paths, mocker, test_dir, computing_envir
     config = Config(config_params)
     mocker.patch("easylink.implementation.Implementation.validate", return_value={})
     pipeline = Pipeline(config)
+    create_results_directory(results_dir)
+    create_results_intermediates(results_dir)
     copy_configuration_files_to_results_directory(**config_paths)
     snakefile = pipeline.build_snakefile()
     expected_file_path = (


### PR DESCRIPTION
## Add DAG visualization
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5270
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I used the `snakemake --dag` functionality to save an .svg image to the results directory.

This gives all the nodes in the snakemake process, including the validations. I actually like this as opposed to, e.g., only showing implementations. It would not be too difficult to do this the other way using networkx, though


The command outputs to stdout a diagram in graphviz DOT format. The standard way to save this as an image is e.g.
snakemake --dag | dot -Tpng > file.png
but doing so on the cluster yields
`Format: "png" not recognized. Use one of: canon cmap cmapx cmapx_np dot dot_json eps fig gv imap imap_np ismap json json0 mp pic plain plain-ext pov ps ps2 svg svgz tk vdx vml vmlz xdot xdot1.2 xdot1.4 xdot_json`
If i try `dot -c` it says:

```
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_gd.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_gdk.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_pango.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_rsvg.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_webp.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_gd.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_gdk.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_pango.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_rsvg.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
Warning: Could not load "/mnt/share/homes/pnast/miniconda3/envs/linker/bin/../lib/graphviz/libgvplugin_webp.so.6" - It was found, so perhaps one of its dependents was not.  Try ldd.
```
ldd'ing any of these suggests that a missing dependent is:
`libXrender.so.1 => not found`

Hopefully, installing `libxrender1` would solve this issue.


### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
see image

