### PR TITLE
Fix bug with parallel validations

### DIFF
--- a/src/easylink/pipeline.py
+++ b/src/easylink/pipeline.py
@@ -85,7 +85,7 @@ class Pipeline:
     def write_implementation_rules(self, node: str) -> None:
         """Write the rules for each implemented step."""
         implementation = self.pipeline_graph.nodes[node]["implementation"]
-        input_files, output_files = self.pipeline_graph.get_input_output_files(node)
+        _input_files, output_files = self.pipeline_graph.get_input_output_files(node)
         input_slots = self.pipeline_graph.get_input_slots(node)
         diagnostics_dir = Path("diagnostics") / node
         diagnostics_dir.mkdir(parents=True, exist_ok=True)
@@ -94,7 +94,7 @@ class Pipeline:
             if self.config.computing_environment == "slurm"
             else None
         )
-        validation_files, validation_rules = self.get_validations(node)
+        validation_files, validation_rules = self.get_validations(node, input_slots)
         implementation_rule = ImplementedRule(
             name=node,
             step_name=implementation.schema_step_name,
@@ -161,11 +161,11 @@ use rule start_spark_worker from spark_cluster with:
                         """
             f.write(module)
 
-    def get_validations(self, node) -> Tuple[List[str], List[InputValidationRule]]:
+    @staticmethod
+    def get_validations(node, input_slots) -> Tuple[List[str], List[InputValidationRule]]:
         """Get validator file and validation rule for each slot for a given node"""
         validation_files = []
         validation_rules = []
-        input_slots = self.pipeline_graph.get_input_slots(node)
 
         for input_slot_name, input_slot_attrs in input_slots.items():
             validation_file = f"input_validations/{node}/{input_slot_name}_validator"

--- a/src/easylink/pipeline.py
+++ b/src/easylink/pipeline.py
@@ -165,19 +165,18 @@ use rule start_spark_worker from spark_cluster with:
         """Get validator file and validation rule for each slot for a given node"""
         validation_files = []
         validation_rules = []
+        input_slots = self.pipeline_graph.get_input_slots(node)
 
-        for _, _, edge_attrs in self.pipeline_graph.in_edges(node, data=True):
-            input_slot = edge_attrs["input_slot"]
-            input_files = edge_attrs["filepaths"]
-            validation_file = f"input_validations/{node}/{input_slot.name}_validator"
+        for input_slot_name, input_slot_attrs in input_slots.items():
+            validation_file = f"input_validations/{node}/{input_slot_name}_validator"
             validation_files.append(validation_file)
             validation_rules.append(
                 InputValidationRule(
                     name=node,
-                    slot_name=input_slot.name,
-                    input=input_files,
+                    slot_name=input_slot_name,
+                    input=input_slot_attrs["filepaths"],
                     output=validation_file,
-                    validator=input_slot.validator,
+                    validator=input_slot_attrs["validator"],
                 )
             )
         return validation_files, validation_rules

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -68,7 +68,7 @@ class PipelineGraph(MultiDiGraph):
                         )
                     ]
 
-    def get_input_slots(self, node: str) -> Dict[str, List[str]]:
+    def get_input_slots(self, node: str) -> dict[str, dict[str, Union[str, list[str]]]]:
         """Get all of a node's input slots from edges."""
         input_slots = {}
         for _, _, edge_attrs in self.in_edges(node, data=True):

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -74,11 +74,10 @@ class PipelineGraph(MultiDiGraph):
     def get_input_slots(self, node: str) -> dict[str, dict[str, Union[str, list[str]]]]:
         """Get all of a node's input slots from edges."""
         input_slots = [
-            copy.deepcopy(edge_attrs["input_slot"])
-            for _, _, edge_attrs in self.in_edges(node, data=True)
+            edge_attrs["input_slot"] for _, _, edge_attrs in self.in_edges(node, data=True)
         ]
         filepaths_by_slot = [
-            copy.deepcopy(edge_attrs["filepaths"])
+            edge_attrs["filepaths"].copy()
             for _, _, edge_attrs in self.in_edges(node, data=True)
         ]
         return self.condense_input_slots(input_slots, filepaths_by_slot)
@@ -117,7 +116,7 @@ class PipelineGraph(MultiDiGraph):
         input_files = list(
             itertools.chain.from_iterable(
                 [
-                    copy.deepcopy(edge_attrs["filepaths"])
+                    edge_attrs["filepaths"].copy()
                     for _, _, edge_attrs in self.in_edges(node, data=True)
                 ]
             )
@@ -125,7 +124,7 @@ class PipelineGraph(MultiDiGraph):
         output_files = list(
             itertools.chain.from_iterable(
                 [
-                    copy.deepcopy(edge_attrs["filepaths"])
+                    edge_attrs["filepaths"].copy()
                     for _, _, edge_attrs in self.out_edges(node, data=True)
                 ]
             )

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -50,26 +50,26 @@ class PipelineGraph(MultiDiGraph):
         ):
             for edge_idx in self[source][sink]:
                 if edge_attrs["output_slot"].name == "all":
-                    self[source][sink][edge_idx]["filepaths"] = [
-                        str(path) for path in config.input_data.to_dict().values()
-                    ]
+                    self[source][sink][edge_idx]["filepaths"] = tuple(
+                        [str(path) for path in config.input_data.to_dict().values()]
+                    )
                 else:
-                    self[source][sink][edge_idx]["filepaths"] = [
-                        str(config.input_data[edge_attrs["output_slot"].name])
-                    ]
+                    self[source][sink][edge_idx]["filepaths"] = (
+                        str(config.input_data[edge_attrs["output_slot"].name]),
+                    )
 
         # Update implementation nodes with yaml metadata
         for node in self.implementation_nodes:
             imp_outputs = self.nodes[node]["implementation"].outputs
             for source, sink, edge_attrs in self.out_edges(node, data=True):
                 for edge_idx in self[node][sink]:
-                    self[source][sink][edge_idx]["filepaths"] = [
+                    self[source][sink][edge_idx]["filepaths"] = (
                         str(
                             Path("intermediate")
                             / node
                             / imp_outputs[edge_attrs["output_slot"].name]
-                        )
-                    ]
+                        ),
+                    )
 
     def get_input_slots(self, node: str) -> dict[str, dict[str, Union[str, list[str]]]]:
         """Get all of a node's input slots from edges."""
@@ -77,7 +77,7 @@ class PipelineGraph(MultiDiGraph):
             edge_attrs["input_slot"] for _, _, edge_attrs in self.in_edges(node, data=True)
         ]
         filepaths_by_slot = [
-            edge_attrs["filepaths"].copy()
+            list(edge_attrs["filepaths"])
             for _, _, edge_attrs in self.in_edges(node, data=True)
         ]
         return self.condense_input_slots(input_slots, filepaths_by_slot)
@@ -116,7 +116,7 @@ class PipelineGraph(MultiDiGraph):
         input_files = list(
             itertools.chain.from_iterable(
                 [
-                    edge_attrs["filepaths"].copy()
+                    list(edge_attrs["filepaths"])
                     for _, _, edge_attrs in self.in_edges(node, data=True)
                 ]
             )
@@ -124,7 +124,7 @@ class PipelineGraph(MultiDiGraph):
         output_files = list(
             itertools.chain.from_iterable(
                 [
-                    edge_attrs["filepaths"].copy()
+                    list(edge_attrs["filepaths"])
                     for _, _, edge_attrs in self.out_edges(node, data=True)
                 ]
             )

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -51,7 +51,7 @@ class PipelineGraph(MultiDiGraph):
             for edge_idx in self[source][sink]:
                 if edge_attrs["output_slot"].name == "all":
                     self[source][sink][edge_idx]["filepaths"] = tuple(
-                        [str(path) for path in config.input_data.to_dict().values()]
+                        str(path) for path in config.input_data.to_dict().values()
                     )
                 else:
                     self[source][sink][edge_idx]["filepaths"] = (

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -1,6 +1,6 @@
 import itertools
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import networkx as nx
 from networkx import MultiDiGraph

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -116,7 +116,7 @@ class PipelineGraph(MultiDiGraph):
         input_files = list(
             itertools.chain.from_iterable(
                 [
-                    list(edge_attrs["filepaths"])
+                    edge_attrs["filepaths"]
                     for _, _, edge_attrs in self.in_edges(node, data=True)
                 ]
             )
@@ -124,7 +124,7 @@ class PipelineGraph(MultiDiGraph):
         output_files = list(
             itertools.chain.from_iterable(
                 [
-                    list(edge_attrs["filepaths"])
+                    edge_attrs["filepaths"]
                     for _, _, edge_attrs in self.out_edges(node, data=True)
                 ]
             )

--- a/tests/unit/test_pipeline_graph.py
+++ b/tests/unit/test_pipeline_graph.py
@@ -24,48 +24,48 @@ def test__create_graph(default_config: Config, test_dir: str) -> None:
             "output_slot_name": "all",
             "validator": validate_input_file_dummy,
             "env_var": "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-            "filepaths": [
+            "filepaths": (
                 Path(f"{test_dir}/input_data1/file1.csv"),
                 Path(f"{test_dir}/input_data2/file2.csv"),
-            ],
+            ),
         },
         ("pipeline_graph_input_data", "step_4_python_pandas"): {
             "input_slot_name": "step_4_secondary_input",
             "output_slot_name": "all",
             "validator": validate_input_file_dummy,
             "env_var": "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS",
-            "filepaths": [
+            "filepaths": (
                 Path(f"{test_dir}/input_data1/file1.csv"),
                 Path(f"{test_dir}/input_data2/file2.csv"),
-            ],
+            ),
         },
         ("step_1_python_pandas", "step_2_python_pandas"): {
             "input_slot_name": "step_2_main_input",
             "output_slot_name": "step_1_main_output",
             "validator": validate_input_file_dummy,
             "env_var": "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-            "filepaths": [Path("intermediate/step_1_python_pandas/result.parquet")],
+            "filepaths": (Path("intermediate/step_1_python_pandas/result.parquet"),),
         },
         ("step_2_python_pandas", "step_3_python_pandas"): {
             "input_slot_name": "step_3_main_input",
             "output_slot_name": "step_2_main_output",
             "validator": validate_input_file_dummy,
             "env_var": "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-            "filepaths": [Path("intermediate/step_2_python_pandas/result.parquet")],
+            "filepaths": (Path("intermediate/step_2_python_pandas/result.parquet"),),
         },
         ("step_3_python_pandas", "step_4_python_pandas"): {
             "input_slot_name": "step_4_main_input",
             "output_slot_name": "step_3_main_output",
             "validator": validate_input_file_dummy,
             "env_var": "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-            "filepaths": [Path("intermediate/step_3_python_pandas/result.parquet")],
+            "filepaths": (Path("intermediate/step_3_python_pandas/result.parquet"),),
         },
         ("step_4_python_pandas", "pipeline_graph_results"): {
             "input_slot_name": "result",
             "output_slot_name": "step_4_main_output",
             "validator": validate_input_file_dummy,
             "env_var": None,
-            "filepaths": [Path("intermediate/step_4_python_pandas/result.parquet")],
+            "filepaths": (Path("intermediate/step_4_python_pandas/result.parquet"),),
         },
     }
     assert set(pipeline_graph.edges()) == expected_edges.keys()
@@ -81,9 +81,9 @@ def test__create_graph(default_config: Config, test_dir: str) -> None:
             edge_attrs["output_slot"].name
             == expected_edges[(source, sink)]["output_slot_name"]
         )
-        assert edge_attrs["filepaths"] == [
-            str(file) for file in expected_edges[(source, sink)]["filepaths"]
-        ]
+        assert edge_attrs["filepaths"] == tuple(
+            [str(file) for file in expected_edges[(source, sink)]["filepaths"]]
+        )
 
 
 def test_implementations(default_config: Config) -> None:
@@ -105,26 +105,26 @@ def test_update_slot_filepaths(default_config: Config, test_dir: str) -> None:
     pipeline_graph = PipelineGraph(default_config)
     pipeline_graph.update_slot_filepaths(default_config)
     expected_filepaths = {
-        ("pipeline_graph_input_data", "step_1_python_pandas"): [
+        ("pipeline_graph_input_data", "step_1_python_pandas"): (
             str(Path(f"{test_dir}/input_data1/file1.csv")),
             str(Path(f"{test_dir}/input_data2/file2.csv")),
-        ],
-        ("pipeline_graph_input_data", "step_4_python_pandas"): [
+        ),
+        ("pipeline_graph_input_data", "step_4_python_pandas"): (
             str(Path(f"{test_dir}/input_data1/file1.csv")),
             str(Path(f"{test_dir}/input_data2/file2.csv")),
-        ],
-        ("step_1_python_pandas", "step_2_python_pandas"): [
+        ),
+        ("step_1_python_pandas", "step_2_python_pandas"): (
             str(Path("intermediate/step_1_python_pandas/result.parquet")),
-        ],
-        ("step_2_python_pandas", "step_3_python_pandas"): [
+        ),
+        ("step_2_python_pandas", "step_3_python_pandas"): (
             str(Path("intermediate/step_2_python_pandas/result.parquet")),
-        ],
-        ("step_3_python_pandas", "step_4_python_pandas"): [
+        ),
+        ("step_3_python_pandas", "step_4_python_pandas"): (
             str(Path("intermediate/step_3_python_pandas/result.parquet")),
-        ],
-        ("step_4_python_pandas", "pipeline_graph_results"): [
+        ),
+        ("step_4_python_pandas", "pipeline_graph_results"): (
             str(Path("intermediate/step_4_python_pandas/result.parquet")),
-        ],
+        ),
     }
     for source, sink, edge_attrs in pipeline_graph.edges(data=True):
         assert edge_attrs["filepaths"] == expected_filepaths[(source, sink)]

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -61,8 +61,16 @@ def test_implemented_rule_build_rule(computing_environment):
         step_name="foo_step",
         implementation_name="foo_imp",
         input_slots={
-            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS": ["foo"],
-            "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS": ["bar"],
+            "main": {
+                "env_var": "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                "filepaths": ["foo"],
+                "validator": lambda x: None,
+            },
+            "secondary": {
+                "env_var": "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS",
+                "filepaths": ["bar"],
+                "validator": lambda x: None,
+            },
         },
         validations=["bar"],
         output=["baz"],


### PR DESCRIPTION
## Fix bug with parallel validations
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5283
- *Research reference*: <!--Link to research documentation for code -->
https://github.com/ihmeuw/easylink/pull/104
### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
As outlined in the linked DAG PR, parallel validations weren't working, because we were improperly accounting for multiple edges utilizing the same slot. I adjusted the way the input slots are collected at snakefile write time, so that if we have multiple edges with the same slot, we test that the validator and environment variable are the same, and then accumulate the filepaths into a single list of filepaths.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
I need to add some unit tests, but the DAG looks correct now:
![image](https://github.com/user-attachments/assets/b5c11d6a-914a-4626-bcc4-8ee3825d21c9)

