### PR TITLE
add missing slot mappings

### DIFF
--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -139,7 +139,21 @@ NODES = [
                     parent_slot="step_4_main_input",
                     child_node="step_4a",
                     child_slot="step_4a_main_input",
-                )
+                ),
+                SlotMapping(
+                    slot_type="input",
+                    parent_node="step_4",
+                    parent_slot="step_4_secondary_input",
+                    child_node="step_4a",
+                    child_slot="step_4a_secondary_input",
+                ),
+                SlotMapping(
+                    slot_type="input",
+                    parent_node="step_4",
+                    parent_slot="step_4_secondary_input",
+                    child_node="step_4b",
+                    child_slot="step_4b_secondary_input",
+                ),
             ],
             "output": [
                 SlotMapping(


### PR DESCRIPTION
## Add missing slot mappings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
In https://github.com/ihmeuw/easylink/pull/101, when I swapped Step #1 with Step #4, i neglected to add the slot mappings for the secondary slots of step 4 because step 1 didn't have slot mappings for that.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
updated DAG
![image](https://github.com/user-attachments/assets/dd11af2d-fa41-4723-87ef-e498a4a017ef)

