### PR TITLE
install python-graphviz with conda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ build-env: # Make a new conda environment
 	conda create ${CONDA_ENV_CREATION_FLAG} python=${PYTHON_VERSION} --yes
 
 install: # Install setuptools, install this package in editable mode
+	conda install python-graphviz
 	pip install --upgrade pip setuptools
 	pip install -e .[DEV]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     install_requirements = [
         "click",
         "docker",
-        "python-graphviz",
+        "pygraphviz",
         "loguru",
         "layered_config_tree",
         "networkx",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     install_requirements = [
         "click",
         "docker",
-        "pygraphviz",
+        "graphviz",
         "loguru",
         "layered_config_tree",
         "networkx",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     install_requirements = [
         "click",
         "docker",
-        "graphviz",
+        "python-graphviz",
         "loguru",
         "layered_config_tree",
         "networkx",


### PR DESCRIPTION
## install python-graphviz with conda
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
jenkins builds are failing with:
`graphviz.backend.execute.ExecutableNotFound: failed to execute PosixPath('dot'), make sure the Graphviz executables are on your systems' PATH`
it seems that pip installing `graphviz` is not enough, as this package requires some graphviz libraries to be installed and configured on the host operating system. `pygraphviz` doesn't seem to work either. `sudo apt install graphviz` is not an available option to us, and I'd prefer not to directly download and install the package from source.

It seems, however, that `conda install python-graphviz` sets this up in the way we need it, maybe because its handling some C libraries. I added it to the Makefile--not sure if there is some other way to manage this more cleanly.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

