### PR TITLE
Set Config as step attribute

### DIFF
--- a/src/easylink/configuration.py
+++ b/src/easylink/configuration.py
@@ -176,6 +176,7 @@ class Config(LayeredConfigTree):
                 errors[PIPELINE_ERRORS_KEY][schema.name] = logs
                 pass  # try the next schema
             else:
+                schema.configure_step(self.pipeline)
                 return schema
         # No schemas were validated
         exit_with_validation_error(dict(errors))

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -23,7 +23,7 @@ class PipelineSchema(CompositeStep):
 
     def get_pipeline_graph(self, pipeline_config: LayeredConfigTree) -> nx.MultiDiGraph:
         """Resolve the PipelineSchema into a PipelineGraph."""
-        self._config = pipeline_config
+        self.configure_step(pipeline_config)
         graph = nx.MultiDiGraph()
         graph.add_node(self.name, step=self)
         self.update_implementation_graph(graph)

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -23,7 +23,6 @@ class PipelineSchema(CompositeStep):
 
     def get_pipeline_graph(self, pipeline_config: LayeredConfigTree) -> nx.MultiDiGraph:
         """Resolve the PipelineSchema into a PipelineGraph."""
-        self.configure_step(pipeline_config)
         graph = nx.MultiDiGraph()
         graph.add_node(self.name, step=self)
         self.update_implementation_graph(graph)

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -18,11 +18,15 @@ class PipelineSchema(CompositeStep):
     def __repr__(self) -> str:
         return f"PipelineSchema.{self.name}"
 
+    def set_step_config(self, parent_config: LayeredConfigTree) -> None:
+        self._config = parent_config
+
     def get_pipeline_graph(self, pipeline_config: LayeredConfigTree) -> nx.MultiDiGraph:
         """Resolve the PipelineSchema into a PipelineGraph."""
+        self._config = pipeline_config
         graph = nx.MultiDiGraph()
         graph.add_node(self.name, step=self)
-        self.update_implementation_graph(graph, pipeline_config)
+        self.update_implementation_graph(graph)
         return graph
 
     @property


### PR DESCRIPTION
## Set Config as step attribute
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This is something I do as part of #108, but it can be extracted as a separate PR, and it will be more readable to do so.

The idea here is to add a separate "configure step" stage, which seeds the step with a step-specific configuration for later steps after validation, so we don't need to do branching aspects of step setup (for say, hierarchical, loop, and parallel steps) multiple times.

The benefits are a little clearer in the context of the other issue, where we do more passes over the configured pipeline schema.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tests pass
