### PR TITLE
add build-doc to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ unit: $(MAKE_SOURCES) # Run unit tests
 	pytest -vvv --runslow --cov --cov-report term --cov-report html:./output/htmlcov_unit tests/unit/
 	@echo "Ignore, Created by Makefile, `date`" > $@
 
+build-doc: $(MAKE_SOURCES) # Build the Sphinx docs
+	$(MAKE) -C docs/ html
+	@echo "Ignore, Created by Makefile, `date`" > $@
+
 clean: # Delete build artifacts and do any custom cleanup such as spinning down services
 	@rm -rf format lint typecheck build-doc build-package unit e2e integration .pytest_cache .pytype
 	@rm -rf dist output


### PR DESCRIPTION
## Add build-doc command to makefile
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

