### PR TITLE
Sbachmei/mic 5861/fix templated step

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.4 - 2/18/25**
+
+ - Implement duplicate_template_step method on TemplatedStep class
+
 **0.1.3 - 1/7/25**
 
  - Validate currently-installed python version during setup

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         "docker",
         "graphviz",
         "loguru",
-        "layered_config_tree",
+        "layered_config_tree>=3.0.0",
         "networkx",
         "pandas",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         "pytest-mock",
     ]
     doc_requirements = [
-        "sphinx<8.2.0",
+        "sphinx",
         "sphinx-rtd-theme",
         "sphinx-autodoc-typehints",
         "sphinx-click",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         "pytest-mock",
     ]
     doc_requirements = [
-        "sphinx",
+        "sphinx<8.2.0",
         "sphinx-rtd-theme",
         "sphinx-autodoc-typehints",
         "sphinx-click",

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -820,13 +820,13 @@ class TemplatedStep(Step, ABC):
 
         Returns
         -------
-            A duplicate of the :attr:`templated_step`.
+            A duplicate of the :attr:`template_step`.
 
         Notes
         -----
-        A naive deepcopy would also make a copy of the :attr:`parent_step`; we don't
+        A naive deepcopy would also make a copy of the :attr:`Step.parent_step`; we don't
         want this to be pointing to a *copy* of `self`, but rather to the original.
-        We thus re-set the :attr:`parent_step` to the original (`self`) after making
+        We thus re-set the :attr:`Step.parent_step` to the original (`self`) after making
         the copy.
         """
         step_copy = copy.deepcopy(self.template_step)

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -818,22 +818,19 @@ class TemplatedStep(Step, ABC):
     def _duplicate_template_step(self) -> Step:
         """Makes a duplicate of the template ``Step``.
 
-        A duplicate of the :attr:`template_step`, i.e. the ``Step`` that may have
-        multiplicity, should contain copies of every attribute of said ``Step``
-        *except* for the :attr:`parent_step`. This is because :attr:`parent_step`
-        contains an actual ``Step`` instance and we want all of the duplicates to
-        have that same parent as opposed to copies of one.
-
         Returns
         -------
             A duplicate of the :attr:`templated_step`.
+        
+        Notes
+        -----
+        A naive deepcopy would also make a copy of the :attr:`parent_step`; we don't 
+        want this to be pointing to a *copy* of `self`, but rather to the original.
+        We thus re-set the :attr:`parent_step` to the original (`self`) after making
+        the copy.
         """
-        # Due to the cyclic nature, self == self.template_step.parent_step
-        parent_step = self
-        self.template_step.parent_step = None
         step_copy = copy.deepcopy(self.template_step)
-        step_copy.set_parent_step(parent_step)
-        self.template_step.set_parent_step(parent_step)
+        step_copy.set_parent_step(self)
         return step_copy
 
 

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -821,10 +821,10 @@ class TemplatedStep(Step, ABC):
         Returns
         -------
             A duplicate of the :attr:`templated_step`.
-        
+
         Notes
         -----
-        A naive deepcopy would also make a copy of the :attr:`parent_step`; we don't 
+        A naive deepcopy would also make a copy of the :attr:`parent_step`; we don't
         want this to be pointing to a *copy* of `self`, but rather to the original.
         We thus re-set the :attr:`parent_step` to the original (`self`) after making
         the copy.

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -828,7 +828,8 @@ class TemplatedStep(Step, ABC):
         -------
             A duplicate of the :attr:`templated_step`.
         """
-        parent_step = self.template_step.parent_step
+        # Due to the cyclic nature, self == self.template_step.parent_step
+        parent_step = self
         self.template_step.parent_step = None
         step_copy = copy.deepcopy(self.template_step)
         step_copy.set_parent_step(parent_step)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -103,7 +103,7 @@ def test_environment_configuration_not_found(computing_environment):
 
 
 @pytest.mark.parametrize(
-    "key, input",
+    "key, value",
     [
         ("computing_environment", None),
         ("computing_environment", "local"),
@@ -114,12 +114,12 @@ def test_environment_configuration_not_found(computing_environment):
         ("container_engine", "undefined"),
     ],
 )
-def test_required_attributes(mocker, default_config_params, key, input):
+def test_required_attributes(mocker, default_config_params, key, value):
     mocker.patch("easylink.configuration.Config._validate_environment")
     config_params = default_config_params
-    if input:
-        config_params["environment"][key] = input
-    env_dict = {key: input} if input else {}
+    if value:
+        config_params["environment"][key] = value
+    env_dict = {key: value} if value else {}
     retrieved = Config(config_params).environment[key]
     expected = DEFAULT_ENVIRONMENT["environment"].copy()
     expected.update(env_dict)
@@ -127,7 +127,7 @@ def test_required_attributes(mocker, default_config_params, key, input):
 
 
 @pytest.mark.parametrize(
-    "input",
+    "resource_request",
     [
         # missing
         None,
@@ -137,22 +137,22 @@ def test_required_attributes(mocker, default_config_params, key, input):
         {"memory": 100, "cpus": 200, "time_limit": 300},
     ],
 )
-def test_implementation_resource_requests(default_config_params, input):
+def test_implementation_resource_requests(default_config_params, resource_request):
     key = "implementation_resources"
     config_params = default_config_params
-    if input:
-        config_params["environment"][key] = input
+    if resource_request:
+        config_params["environment"][key] = resource_request
     config = Config(config_params)
-    env_dict = {key: input.copy()} if input else {}
+    env_dict = {key: resource_request.copy()} if resource_request else {}
     retrieved = config.environment[key].to_dict()
     expected = DEFAULT_ENVIRONMENT["environment"][key].copy()
-    if input:
+    if resource_request:
         expected.update(env_dict[key])
     assert retrieved == expected
 
 
 @pytest.mark.parametrize(
-    "input",
+    "spark_request",
     [
         # missing
         None,
@@ -179,7 +179,7 @@ def test_implementation_resource_requests(default_config_params, input):
     ],
 )
 @pytest.mark.parametrize("requires_spark", [True, False])
-def test_spark_requests(default_config_params, input, requires_spark):
+def test_spark_requests(default_config_params, spark_request, requires_spark):
     key = "spark"
     config_params = default_config_params
     if requires_spark:
@@ -188,12 +188,12 @@ def test_spark_requests(default_config_params, input, requires_spark):
             "name"
         ] = "step_1_python_pyspark"
 
-    if input:
-        config_params["environment"][key] = input
+    if spark_request:
+        config_params["environment"][key] = spark_request
     retrieved = Config(config_params).environment[key].to_dict()
-    expected_env_dict = {key: input.copy()} if input else {}
+    expected_env_dict = {key: spark_request.copy()} if spark_request else {}
     expected = LayeredConfigTree(SPARK_DEFAULTS, layers=["initial_data", "user"])
-    if input:
+    if spark_request:
         expected.update(expected_env_dict[key], layer="user")
     expected = expected.to_dict()
     assert retrieved == expected

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -632,9 +632,9 @@ def test_parallel_step_get_implementation_graph(
 @pytest.mark.parametrize("step_type", ["parallel", "loop"])
 def test__duplicate_template_step(step_type):
     """Test against _duplicate_template_step.
-    
+
     This is not an exhaustive test due to the complicated nature of testing
-    equality of different attributes between two deep copies. For example, 
+    equality of different attributes between two deep copies. For example,
     SomeClass.foo == SomeOtherClass.foo if foo is the same string even though
     they are different objects in memory. This is not the case for methods as
     well as other attribute types.

--- a/tests/unit/test_validations.py
+++ b/tests/unit/test_validations.py
@@ -467,3 +467,8 @@ def test_implemenation_does_not_match_step(default_config, caplog, mocker):
             },
         },
     )
+
+
+def test_nested_templates():
+    """Tests that nested TemplatedSteps pass validation."""
+    ...


### PR DESCRIPTION
## Support nested templated steps and no multiplicity

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5861
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The primary goal of this is to handle cases where the user does not actually
include the config_key for a particular TemplatedStep (i.e. no multiplicity
despite being a LoopStep or ParallelStep) but does specify a 
_different_ config key, e.g. a ParallelStep of LoopSteps but where
there is no actual multiplicity on the outer ParallelStep.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

