### PR TITLE
require Step during construction of EmbarrassinglyParalleStep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.9 - 3/14/25**
+
+ - Refactor EmbarrassinglyParallelStep to require a Step during construction
+
 **0.1.8 - 3/13/25**
 
  - Refactor subgraph logic from Step to HierarchicalStep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ exclude = [
     'src/easylink/pipeline_graph.py',
     'src/easylink/pipeline.py',
     'src/easylink/pipeline_schema.py',
+    'src/easylink/pipeline_schema_constants/testing.py',
+    'src/easylink/pipeline_schema_constants/development.py',
     'src/easylink/rule.py',
     'src/easylink/runner.py',
     'src/easylink/step.py',

--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -59,21 +59,23 @@ NODES = [
     ),
     LoopStep(
         template_step=EmbarrassinglyParallelStep(
-            step_name="step_3",
-            input_slots=[
-                InputSlot(
-                    name="step_3_main_input",
-                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-                    validator=validate_input_file_dummy,
-                    splitter=split_data_by_size,
-                ),
-            ],
-            output_slots=[
-                OutputSlot(
-                    name="step_3_main_output",
-                    aggregator=concatenate_datasets,
-                ),
-            ],
+            step=Step(
+                step_name="step_3",
+                input_slots=[
+                    InputSlot(
+                        name="step_3_main_input",
+                        env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                        validator=validate_input_file_dummy,
+                        splitter=split_data_by_size,
+                    ),
+                ],
+                output_slots=[
+                    OutputSlot(
+                        name="step_3_main_output",
+                        aggregator=concatenate_datasets,
+                    ),
+                ],
+            ),
         ),
         self_edges=[
             EdgeParams(

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1138,19 +1138,25 @@ class EmbarrassinglyParallelStep(Step):
 
     An ``EmbarrassinglyParallelStep`` is different than a :class:`ParallelStep`
     in that it is not configured by the user to be run in parallel - it completely
-    happens on the back end for performance reasons. As such, note that it inherits
-    from :class:`Step` instead of :class:`TemplatedStep`.
+    happens on the back end for performance reasons.
 
     See :class:`Step` for inherited attributes.
+
+    Parameters
+    ----------
+    step
+        The ``Step`` to be run in an embarrassingly parallel manner. To run multiple
+        steps in parallel, use a :class:`HierarchicalStep`.
+
     """
 
     def __init__(
         self,
-        step_name: str,
-        input_slots: Iterable[InputSlot],
-        output_slots: Iterable[OutputSlot],
+        step: Step,
     ) -> None:
-        super().__init__(step_name, input_slots=input_slots, output_slots=output_slots)
+        super().__init__(
+            step.step_name, step.name, step.input_slots.values(), step.output_slots.values()
+        )
         self._validate()
 
     def _validate(self) -> None:

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1114,16 +1114,18 @@ def test_complex_choice_step_get_implementation_graph(
 @pytest.fixture
 def embarrassingly_parallel_step_params() -> dict[str, Any]:
     return {
-        "step_name": "step_3",
-        "input_slots": [
-            InputSlot(
-                "step_3_main_input",
-                "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-                validate_input_file_dummy,
-                split_data_by_size,
-            )
-        ],
-        "output_slots": [OutputSlot("step_3_main_output", concatenate_datasets)],
+        "step": Step(
+            step_name="step_3",
+            input_slots=[
+                InputSlot(
+                    "step_3_main_input",
+                    "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validate_input_file_dummy,
+                    split_data_by_size,
+                )
+            ],
+            output_slots=[OutputSlot("step_3_main_output", concatenate_datasets)],
+        ),
     }
 
 
@@ -1261,9 +1263,11 @@ def test_embarrassingly_parallel_step__validation(
     expected_error_msg: str | list[str],
 ):
     step_params = {
-        "step_name": "step",
-        "input_slots": input_slots,
-        "output_slots": output_slots,
+        "step": Step(
+            step_name="step",
+            input_slots=input_slots,
+            output_slots=output_slots,
+        ),
     }
     with pytest.raises(ValueError) as error:
         EmbarrassinglyParallelStep(**step_params)


### PR DESCRIPTION
## Refactor EmbarrassinglyParallelStep to require a single Step

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5907
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This does NOT add new features - it's a slight refactor to EmbarrassinglyParallelStep
so that it requires a 'step' argument during construction. For now, the only supported
step type is a basic Step - a following PR will impelment support for a 
HierarchicalStep (which means support for embarrassingly parallel
_sections_ as opposed to simply discrete steps).

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

