### PR TITLE
Sbachmei/mic 5946/unfreeze input output slots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.10 - 3/24/25**
+
+ - Make InputSlots and OutputSlots mutable
+
 **0.1.9 - 3/14/25**
 
  - Refactor EmbarrassinglyParallelStep to require a Step during construction

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.1.10 - 3/24/25**
+**0.1.10 - 3/25/25**
 
  - Make InputSlots and OutputSlots mutable
 

--- a/tests/unit/test_graph_components.py
+++ b/tests/unit/test_graph_components.py
@@ -7,7 +7,6 @@ from easylink.graph_components import (
     InputSlotMapping,
     OutputSlot,
     OutputSlotMapping,
-    SlotMapping,
     StepGraph,
 )
 from easylink.implementation import Implementation
@@ -27,6 +26,86 @@ def test_input_slot() -> None:
 def test_output_slot() -> None:
     output_slot = OutputSlot("file1")
     assert output_slot.name == "file1"
+
+
+def test_input_slot_hashing() -> None:
+    slot = InputSlot("slot", "foo", validate_input_file_dummy)
+    slot_dupe = InputSlot("slot", "foo", validate_input_file_dummy)
+    assert slot == slot_dupe
+    assert {slot, slot_dupe} == {slot}
+
+    slot_with_splitter = InputSlot("slot", "foo", validate_input_file_dummy, dummy_splitter)
+
+    assert slot != slot_with_splitter
+    assert {slot, slot_with_splitter, slot, slot_with_splitter} == {
+        slot,
+        slot_with_splitter,
+    }
+
+    slot_with_different_splitter = InputSlot(
+        "slot", "foo", validate_input_file_dummy, dummy_splitter_2
+    )
+    assert slot_with_splitter != slot_with_different_splitter
+    assert {
+        slot,
+        slot_dupe,
+        slot_with_splitter,
+        slot_with_different_splitter,
+        slot_with_splitter,
+        slot_with_different_splitter,
+    } == {
+        slot,
+        slot_with_splitter,
+        slot_with_different_splitter,
+    }
+
+
+def test_output_slot_hashing() -> None:
+    slot = OutputSlot("slot")
+    slot_dupe = OutputSlot("slot")
+    assert slot == slot_dupe
+    assert {slot, slot_dupe} == {slot}
+
+    slot_with_aggregator = OutputSlot("slot", dummy_aggregator)
+
+    assert slot != slot_with_aggregator
+    assert {slot, slot_with_aggregator, slot, slot_with_aggregator} == {
+        slot,
+        slot_with_aggregator,
+    }
+
+    slot_with_different_aggregator = OutputSlot("slot", dummy_aggregator_2)
+    assert slot_with_aggregator != slot_with_different_aggregator
+    assert {
+        slot,
+        slot_dupe,
+        slot_with_aggregator,
+        slot_with_different_aggregator,
+        slot_with_aggregator,
+        slot_with_different_aggregator,
+    } == {
+        slot,
+        slot_with_aggregator,
+        slot_with_different_aggregator,
+    }
+
+    input_slot = InputSlot("slot", "foo", validate_input_file_dummy)
+
+
+def test_slot_mutability() -> None:
+    slot = InputSlot("slot", "foo", validate_input_file_dummy)
+    assert slot.splitter is None
+    slot.splitter = dummy_splitter
+    assert slot.splitter == dummy_splitter
+    slot.splitter = dummy_splitter_2
+    assert slot.splitter == dummy_splitter_2
+
+    slot = OutputSlot("slot")
+    assert slot.aggregator is None
+    slot.aggregator = dummy_aggregator
+    assert slot.aggregator == dummy_aggregator
+    slot.aggregator = dummy_aggregator_2
+    assert slot.aggregator == dummy_aggregator_2
 
 
 def test_edge() -> None:
@@ -136,3 +215,24 @@ def test_output_slot_mapping() -> None:
     assert new_edge.target_node == "output_data"
     assert new_edge.output_slot == "step_1a_main_input"
     assert new_edge.input_slot == "file1"
+
+
+####################
+# Helper functions #
+####################
+
+
+def dummy_splitter():
+    pass
+
+
+def dummy_splitter_2():
+    pass
+
+
+def dummy_aggregator():
+    pass
+
+
+def dummy_aggregator_2():
+    pass

--- a/tests/unit/test_graph_components.py
+++ b/tests/unit/test_graph_components.py
@@ -59,6 +59,13 @@ def test_input_slot_hashing() -> None:
         slot_with_different_splitter,
     }
 
+    slot_with_different_validator = InputSlot("slot", "foo", dummy_validator)
+    assert slot != slot_with_different_validator
+    assert {slot, slot_dupe, slot_with_different_validator} == {
+        slot,
+        slot_with_different_validator,
+    }
+
 
 def test_output_slot_hashing() -> None:
     slot = OutputSlot("slot")
@@ -235,4 +242,8 @@ def dummy_aggregator():
 
 
 def dummy_aggregator_2():
+    pass
+
+
+def dummy_validator():
     pass

--- a/tests/unit/test_pipeline_graph.py
+++ b/tests/unit/test_pipeline_graph.py
@@ -99,24 +99,42 @@ def test_implementations(default_config: Config) -> None:
             "input_slot",
             False,
             {
-                ("step_a", InputSlot("foo", env_var="bar", validator=None)),
-                ("step_b", InputSlot("baz", env_var="spam", validator=None)),
+                (
+                    "step_a",
+                    InputSlot("foo", env_var="bar", validator=validate_input_file_dummy),
+                ),
+                (
+                    "step_b",
+                    InputSlot("baz", env_var="spam", validator=validate_input_file_dummy),
+                ),
             },
         ),
         (
             "input_slot",
             True,
             {
-                ("step_a", InputSlot("foo", env_var="bar", validator=None)),
-                ("step_b", InputSlot("foo", env_var="spam", validator=None)),
+                (
+                    "step_a",
+                    InputSlot("foo", env_var="bar", validator=validate_input_file_dummy),
+                ),
+                (
+                    "step_b",
+                    InputSlot("foo", env_var="spam", validator=validate_input_file_dummy),
+                ),
             },
         ),
         (
             "input_slot",
             True,
             {
-                ("step_a", InputSlot("foo", env_var="bar", validator=None)),
-                ("step_b", InputSlot("baz", env_var="bar", validator=None)),
+                (
+                    "step_a",
+                    InputSlot("foo", env_var="bar", validator=validate_input_file_dummy),
+                ),
+                (
+                    "step_b",
+                    InputSlot("baz", env_var="bar", validator=validate_input_file_dummy),
+                ),
             },
         ),
         (


### PR DESCRIPTION
## Make InputSlots and OutputSlots mutable

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5946
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> In order to pave the way for updating Input/OutputSlots by passing
down an EmbarrassinglyParallelStep's splitter and aggregator to the appropriate
sub-steps, we needed to unfreeze the dataclasses. This also meant implementing
__hash__ (b/c we rely on that in tests). I went ahead and implemented
__eq__ while I was there, though we don't currently use that anywhere.

NOTE: The hashing is not perfect in that it simply hashes the names of all
callables.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

