### PR TITLE
Sbachmei/mic 5947/pass splitters aggregators to implementations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Test
         # NOTE: We only run tests not marked as `slow` here since github actions
         # does not have access to the cluster (which is required for some tests). 
-        # This means that we may inadvertenlly deploy code that has failing tests!
+        # This means that we may inadvertently deploy code that has failing tests!
         run: |
           pip install .[test]
           pytest ./tests

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,33 +1,33 @@
 # -----------------------------------------------------------------------------
 #   - invoked on push to any branch
 # -----------------------------------------------------------------------------
-    name: update README
+name: update README
 
-    on: push
-    
-    jobs:
-      update-readme:
-        runs-on: ubuntu-latest
-        steps:
-          - name: Checkout code
-            uses: actions/checkout@v2
-          - name: Set up Python
-            uses: actions/setup-python@v2
-            with:
-              python-version: 3.11
-          - name: Update README
-            run: |
-              pip install packaging
-              python update_readme.py
-          - name: Commit and push changes
-            run: |
-              git config --local user.email "action@github.com"
-              git config --local user.name "github-actions"
-              git diff --quiet && git diff --staged --quiet || (
-                git add README.rst
-                git commit -am "update README with supported Python versions"
-                git pull --rebase origin ${{ github.ref_name }}
-                git push origin ${{ github.ref_name }}
-              )
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on: push
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Update README
+        run: |
+          pip install packaging
+          python update_readme.py
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions"
+          git diff --quiet && git diff --staged --quiet || (
+            git add README.rst
+            git commit -am "update README with supported Python versions"
+            git pull --rebase origin ${{ github.ref_name }}
+            git push origin ${{ github.ref_name }}
+          )
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.1.12 - TBD/TBD/TBD**
+**0.1.12 - 4/1/25**
 
  - Propagate embarrassingly parallel splitters and aggregators to leaf steps
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.12 - TBD/TBD/TBD**
+
+ - Propagate embarrassingly parallel splitters and aggregators to leaf steps
+
 **0.1.11 - 3/28/25**
 
  - Refactor the ImplementationGraph recursion logic for clarity

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,5 @@
 reusable_pipeline(scheduled_branches: ["main"], 
                   test_types: ["unit", "integration", "e2e"], 
                   upstream_repos: ["layered_config_tree"], 
-                  python_versions: ["3.11","3.12"], 
                   requires_slurm: true, 
                   use_shared_fs: true)

--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -66,16 +66,37 @@ NODES = [
                         name="step_3_main_input",
                         env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                         validator=validate_input_file_dummy,
-                        splitter=split_data_by_size,
                     ),
                 ],
                 output_slots=[
                     OutputSlot(
                         name="step_3_main_output",
-                        aggregator=concatenate_datasets,
                     ),
                 ],
             ),
+            input_slots=[
+                InputSlot(
+                    name="step_3_main_input",
+                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validator=validate_input_file_dummy,
+                    splitter=split_data_by_size,
+                ),
+            ],
+            output_slots=[OutputSlot("step_3_main_output", aggregator=concatenate_datasets)],
+            input_slot_mappings=[
+                InputSlotMapping(
+                    parent_slot="step_3_main_input",
+                    child_node="step_3",
+                    child_slot="step_3_main_input",
+                ),
+            ],
+            output_slot_mappings=[
+                OutputSlotMapping(
+                    parent_slot="step_3_main_output",
+                    child_node="step_3",
+                    child_slot="step_3_main_output",
+                ),
+            ],
         ),
         self_edges=[
             EdgeParams(
@@ -276,12 +297,14 @@ EDGES = [
         target_node="step_2",
         output_slot="step_1_main_output",
         input_slot="step_2_main_input",
+        # splitter=(splitting_function, "step_3"),  # is this somehow better?
     ),
     EdgeParams(
         source_node="step_2",
         target_node="step_3",
         output_slot="step_2_main_output",
         input_slot="step_3_main_input",
+        # aggregator=...,  # is this somehow better?
     ),
     EdgeParams(
         source_node="step_3",

--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -297,14 +297,12 @@ EDGES = [
         target_node="step_2",
         output_slot="step_1_main_output",
         input_slot="step_2_main_input",
-        # splitter=(splitting_function, "step_3"),  # is this somehow better?
     ),
     EdgeParams(
         source_node="step_2",
         target_node="step_3",
         output_slot="step_2_main_output",
         input_slot="step_3_main_input",
-        # aggregator=...,  # is this somehow better?
     ),
     EdgeParams(
         source_node="step_3",

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1183,7 +1183,7 @@ class EmbarrassinglyParallelStep(Step):
         )
         self.step_graph = None
         self.step = step
-        self.step.is_embarrassingly_parallel = True
+        # self.step.is_embarrassingly_parallel = True
         self._validate()
 
     def _validate(self) -> None:
@@ -1723,6 +1723,10 @@ class NonLeafConfigurationState(ConfigurationState):
         """
         for node in self._step.step_graph.nodes:
             substep = self._step.step_graph.nodes[node]["step"]
+            if self._step.is_embarrassingly_parallel:
+                # If the parent step is embarrassingly parallel, we need to set the substep's
+                # is_embarrassingly_parallel attribute to True as well
+                substep.is_embarrassingly_parallel = True
             self._propagate_splitter_aggregators(self._step, substep)
             substep.add_nodes_to_implementation_graph(implementation_graph)
 

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -109,7 +109,7 @@ class Step:
         """A combined dictionary containing both the ``InputSlotMappings`` and
         ``OutputSlotMappings`` of this ``Step``."""
         self.is_embarrassingly_parallel = is_embarrassingly_parallel
-        """TODO"""
+        """Whether or not this ``Step`` is to be run in an embarrassingly parallel manner."""
         self.parent_step = None
         """This ``Step's`` parent ``Step``, if applicable."""
         self._configuration_state = None

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -87,6 +87,7 @@ class Step:
         output_slots: Iterable[OutputSlot] = (),
         input_slot_mappings: Iterable[InputSlotMapping] = (),
         output_slot_mappings: Iterable[OutputSlotMapping] = (),
+        is_embarrassingly_parallel: bool = False,
     ) -> None:
         self.step_name = step_name
         """The name of the pipeline step in the ``PipelineSchema``. It must also match
@@ -107,6 +108,8 @@ class Step:
         }
         """A combined dictionary containing both the ``InputSlotMappings`` and
         ``OutputSlotMappings`` of this ``Step``."""
+        self.is_embarrassingly_parallel = is_embarrassingly_parallel
+        """TODO"""
         self.parent_step = None
         """This ``Step's`` parent ``Step``, if applicable."""
         self._configuration_state = None
@@ -884,7 +887,7 @@ class TemplatedStep(Step, ABC):
             self.step_graph = StepGraph()
             self.template_step.name = self.name
             self.step_graph.add_node_from_step(self.template_step)
-            # Special handle the slot_mappings update
+            # Update the slot mappings with renamed children
             input_mappings = [
                 InputSlotMapping(slot, self.name, slot) for slot in self.input_slots
             ]
@@ -1164,10 +1167,23 @@ class EmbarrassinglyParallelStep(Step):
     def __init__(
         self,
         step: Step,
+        input_slots: Iterable[InputSlot],
+        output_slots: Iterable[OutputSlot],
+        input_slot_mappings: Iterable[InputSlotMapping],
+        output_slot_mappings: Iterable[OutputSlotMapping],
     ) -> None:
         super().__init__(
-            step.step_name, step.name, step.input_slots.values(), step.output_slots.values()
+            step.step_name,
+            step.name,
+            input_slots,
+            output_slots,
+            input_slot_mappings,
+            output_slot_mappings,
+            is_embarrassingly_parallel=True,
         )
+        self.step_graph = None
+        self.step = step
+        self.step.is_embarrassingly_parallel = True
         self._validate()
 
     def _validate(self) -> None:
@@ -1209,6 +1225,115 @@ class EmbarrassinglyParallelStep(Step):
             )
         if errors:
             raise ValueError("\n".join(errors))
+
+    def validate_step(
+        self,
+        step_config: LayeredConfigTree,
+        combined_implementations: LayeredConfigTree,
+        input_data_config: LayeredConfigTree,
+    ) -> dict[str, list[str]]:
+        """Validates the ``Step`` assigned to this ``EmbarrassinglyParallelStep``.
+
+        Parameters
+        ----------
+        step_config
+            The internal configuration of this ``Step``, i.e. it should not include
+            the ``Step's`` name.
+        combined_implementations
+            The configuration for any implementations to be combined.
+        input_data_config
+            The input data configuration for the entire pipeline.
+
+        Returns
+        -------
+            A dictionary of errors, where the keys are the ``Step`` name and the
+            values are lists of associated error messages.
+
+        Notes
+        -----
+        If the ``EmbarrassinglyParallelStep`` does not validate (i.e. errors are
+        found and the returned dictionary is non-empty), the tool will exit and
+        the pipeline will not run.
+
+        We attempt to batch error messages as much as possible, but there may be
+        times where the configuration is so ill-formed that we are unable to handle
+        all issue in one pass. In these cases, new errors may be found after the
+        initial ones are handled.
+        """
+        return self.step.validate_step(
+            LayeredConfigTree(step_config),
+            combined_implementations,
+            input_data_config,
+        )
+
+    def set_configuration_state(
+        self,
+        step_config: LayeredConfigTree,
+        combined_implementations: LayeredConfigTree,
+        input_data_config: LayeredConfigTree,
+    ):
+        """Sets the configuration state to 'non-leaf'.
+
+        In addition to setting the configuration state, this also updates the
+        :class:`~easylink.graph_components.StepGraph` and
+        :class:`SlotMappings<easylink.graph_components.SlotMapping>`.
+
+        Parameters
+        ----------
+        step_config
+            The internal configuration of this ``Step``, i.e. it should not include
+            the ``Step's`` name.
+        combined_implementations
+            The configuration for any implementations to be combined.
+        input_data_config
+            The input data configuration for the entire pipeline.
+        """
+        if self.name != self.step.name:
+            # Update the slot mappings if the children have been renamed
+            self.step.name = self.name
+            input_mappings = [
+                InputSlotMapping(slot, self.name, slot) for slot in self.input_slots
+            ]
+            output_mappings = [
+                OutputSlotMapping(slot, self.name, slot) for slot in self.output_slots
+            ]
+            self.slot_mappings = {"input": input_mappings, "output": output_mappings}
+        # Generate step graph from the single ``step`` attr
+        self.step_graph = StepGraph()
+        self.step_graph.add_node_from_step(self.step)
+        # Add the key back to the expanded config
+        expanded_config = LayeredConfigTree({self.name: step_config})
+
+        # Traverse the step_graph to add the splitter/aggregators to the appropriate i/o slots
+        parent_node = self
+        child_node = self.step
+        for parent_input_slot_name, parent_input_slot in parent_node.input_slots.items():
+            if parent_input_slot.splitter:
+                parent_slot_mapping = [
+                    mapping
+                    for mapping in parent_node.slot_mappings["input"]
+                    if mapping.parent_slot == parent_input_slot_name
+                ][0]
+                child_node.input_slots[
+                    parent_slot_mapping.child_slot
+                ].splitter = parent_input_slot.splitter
+        for parent_output_slot_name, parent_output_slot in parent_node.output_slots.items():
+            parent_slot_mapping = [
+                mapping
+                for mapping in parent_node.slot_mappings["output"]
+                if mapping.parent_slot == parent_output_slot_name
+            ][0]
+            child_node.output_slots[
+                parent_slot_mapping.child_slot
+            ].aggregator = parent_output_slot.aggregator
+
+        # Manually set the configuration state to non-leaf instead of relying
+        # on super().get_configuration_state() because that method will erroneously
+        # set to leaf state in the event the user didn't include the config_key
+        # in the pipeline specification.
+        self._configuration_state = NonLeafConfigurationState(
+            self, expanded_config, combined_implementations, input_data_config
+        )
 
 
 class ChoiceStep(Step):
@@ -1469,10 +1594,10 @@ class LeafConfigurationState(ConfigurationState):
         """
         step = self._step
         if self.is_combined:
-            if isinstance(step, EmbarrassinglyParallelStep):
+            if step.is_embarrassingly_parallel:
                 raise NotImplementedError(
                     "Combining implementations with embarrassingly parallel steps "
-                    "is not yet supported."
+                    "is not supported."
                 )
             implementation = PartialImplementation(
                 combined_name=self.step_config[COMBINED_IMPLEMENTATION_KEY],
@@ -1486,7 +1611,7 @@ class LeafConfigurationState(ConfigurationState):
                 implementation_config=self.implementation_config,
                 input_slots=step.input_slots.values(),
                 output_slots=step.output_slots.values(),
-                is_embarrassingly_parallel=isinstance(step, EmbarrassinglyParallelStep),
+                is_embarrassingly_parallel=step.is_embarrassingly_parallel,
             )
         implementation_graph.add_node_from_implementation(
             step.implementation_node_name,
@@ -1608,7 +1733,6 @@ class NonLeafConfigurationState(ConfigurationState):
                 "NonLeafConfigurationState requires a subgraph upon which to operate, "
                 f"but Step {step.name} has no step graph."
             )
-        self._nodes = step.step_graph.nodes
         self._configure_subgraph_steps()
 
     def add_nodes_to_implementation_graph(
@@ -1643,8 +1767,8 @@ class NonLeafConfigurationState(ConfigurationState):
         # Add the edges at this level (i.e. the edges at this `self._step`)
         for source, target, edge_attrs in self._step.step_graph.edges(data=True):
             edge = EdgeParams.from_graph_edge(source, target, edge_attrs)
-            source_step = self._nodes[source]["step"]
-            target_step = self._nodes[target]["step"]
+            source_step = self._step.step_graph.nodes[source]["step"]
+            target_step = self._step.step_graph.nodes[target]["step"]
 
             source_edges = source_step.get_implementation_edges(edge)
             for source_edge in source_edges:
@@ -1707,7 +1831,7 @@ class NonLeafConfigurationState(ConfigurationState):
             ]
             for mapping in mappings:
                 new_edge = mapping.remap_edge(edge)
-                new_step = self._nodes[mapping.child_node]["step"]
+                new_step = self._step.step_graph.nodes[mapping.child_node]["step"]
                 imp_edges = new_step.get_implementation_edges(new_edge)
                 implementation_edges.extend(imp_edges)
         elif edge.target_node == self._step.name:
@@ -1718,7 +1842,7 @@ class NonLeafConfigurationState(ConfigurationState):
             ]
             for mapping in mappings:
                 new_edge = mapping.remap_edge(edge)
-                new_step = self._nodes[mapping.child_node]["step"]
+                new_step = self._step.step_graph.nodes[mapping.child_node]["step"]
                 imp_edges = new_step.get_implementation_edges(new_edge)
                 implementation_edges.extend(imp_edges)
         else:
@@ -1733,12 +1857,14 @@ class NonLeafConfigurationState(ConfigurationState):
         This method recursively traverses the ``StepGraph`` and sets the configuration
         state for each ``Step`` until reaching all leaf nodes.
         """
-        for node in self._nodes:
-            step = self._nodes[node]["step"]
+        for sub_node in self._step.step_graph.nodes:
+            sub_step = self._step.step_graph.nodes[sub_node]["step"]
             # IOStep names never appear in configuration
             step_config = (
-                self.step_config if isinstance(step, IOStep) else self.step_config[step.name]
+                self.step_config
+                if isinstance(sub_step, IOStep)
+                else self.step_config[sub_step.name]
             )
-            step.set_configuration_state(
+            sub_step.set_configuration_state(
                 step_config, self.combined_implementations, self.input_data_config
             )

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1288,8 +1288,9 @@ class EmbarrassinglyParallelStep(Step):
         input_data_config
             The input data configuration for the entire pipeline.
         """
-        if self.name != self.step.name:
-            # Update the slot mappings if the children have been renamed
+        if self.step.name != self.name:
+            # Update the step name if the parent got renamed, e.g. a parent LoopStep 
+            # 'step_1' that got expanded to 'step_1_loop_1', etc.
             self.step.name = self.name
             input_mappings = [
                 InputSlotMapping(slot, self.name, slot) for slot in self.input_slots

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1756,16 +1756,12 @@ class NonLeafConfigurationState(ConfigurationState):
                     for mapping in parent.slot_mappings["input"]
                     if mapping.parent_slot == parent_input_slot_name
                 ]
-                if len(mappings_with_splitter) > 1:
-                    raise NotImplementedError(
-                        "Multiple mappings from a single parent slot is not supported."
-                    )
-                child_node = mappings_with_splitter[0].child_node
-                child_slot = mappings_with_splitter[0].child_slot
-
-                # Assign the splitter to the appropriate child slot
-                if child_slot in child.input_slots and child_node == child.name:
-                    child.input_slots[child_slot].splitter = parent_input_slot.splitter
+                for mapping in mappings_with_splitter:
+                    child_node = mapping.child_node
+                    child_slot = mapping.child_slot
+                    # Assign the splitter to the appropriate child slot
+                    if child_slot in child.input_slots and child_node == child.name:
+                        child.input_slots[child_slot].splitter = parent_input_slot.splitter
         for parent_output_slot_name, parent_output_slot in parent.output_slots.items():
             # Extract the appropriate child slot name from the mapping
             mappings_from_parent = [
@@ -1773,15 +1769,12 @@ class NonLeafConfigurationState(ConfigurationState):
                 for mapping in parent.slot_mappings["output"]
                 if mapping.parent_slot == parent_output_slot_name
             ]
-            if len(mappings_from_parent) > 1:
-                raise NotImplementedError(
-                    "Multiple mappings from a single parent slot is not supported."
-                )
-            child_node = mappings_from_parent[0].child_node
-            child_slot = mappings_from_parent[0].child_slot
-            # Assign the aggregator to the appropriate child slot
-            if child_slot in child.output_slots and child_node == child.name:
-                child.output_slots[child_slot].aggregator = parent_output_slot.aggregator
+            for mapping in mappings_from_parent:
+                child_node = mapping.child_node
+                child_slot = mapping.child_slot
+                # Assign the aggregator to the appropriate child slot
+                if child_slot in child.output_slots and child_node == child.name:
+                    child.output_slots[child_slot].aggregator = parent_output_slot.aggregator
 
     def add_edges_to_implementation_graph(
         self, implementation_graph: ImplementationGraph

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1289,7 +1289,7 @@ class EmbarrassinglyParallelStep(Step):
             The input data configuration for the entire pipeline.
         """
         if self.step.name != self.name:
-            # Update the step name if the parent got renamed, e.g. a parent LoopStep 
+            # Update the step name if the parent got renamed, e.g. a parent LoopStep
             # 'step_1' that got expanded to 'step_1_loop_1', etc.
             self.step.name = self.name
             input_mappings = [

--- a/tests/unit/test_pipeline_graph.py
+++ b/tests/unit/test_pipeline_graph.py
@@ -837,5 +837,5 @@ def check_nodes_and_edges(pipeline_graph, expected_nodes, expected_edges):
             == expected_edges[(source, sink)]["output_slot_name"]
         )
         assert edge_attrs["filepaths"] == tuple(
-            [str(file) for file in expected_edges[(source, sink)]["filepaths"]]
+            str(file) for file in expected_edges[(source, sink)]["filepaths"]
         )

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1168,9 +1168,10 @@ def test_embarrassingly_parallel_step_implementation_graph(
     assert list(subgraph.nodes) == ["step_3_python_pandas"]
     assert list(subgraph.edges) == []
 
-    # Check that leaf nodes have splitter and aggregators
-    assert ep_step.step.input_slots["step_3_main_input"].splitter == split_data_by_size
-    assert ep_step.step.output_slots["step_3_main_output"].aggregator == concatenate_datasets
+    # Check that the implementation has the splitter and aggregator
+    implementation = subgraph.nodes["step_3_python_pandas"]["implementation"]
+    assert implementation.input_slots["step_3_main_input"].splitter == split_data_by_size
+    assert implementation.output_slots["step_3_main_output"].aggregator == concatenate_datasets
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -88,9 +88,9 @@ def test_io_step_slots(io_step_params: dict[str, Any]) -> None:
 
 def test_io_implementation_graph(io_step_params: dict[str, Any]) -> None:
     step = IOStep(**io_step_params)
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == ["io"]
-    assert list(subgraph.edges) == []
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == ["io"]
+    assert list(implementation_graph.edges) == []
 
 
 def test_basic_step_slots(basic_step_params: dict[str, Any]) -> None:
@@ -111,9 +111,9 @@ def test_basic_step_implementation_graph(
 ) -> None:
     step = Step(**basic_step_params)
     step.set_configuration_state(default_config["pipeline"]["steps"][step.name], {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == ["step_1_python_pandas"]
-    assert list(subgraph.edges) == []
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == ["step_1_python_pandas"]
+    assert list(implementation_graph.edges) == []
 
 
 @pytest.fixture
@@ -185,9 +185,9 @@ def test_hierarchical_step_implementation_graph(
         {"implementation": {"name": "step_4_python_pandas", "configuration": {}}}
     )
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == ["step_4_python_pandas"]
-    assert list(subgraph.edges) == []
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == ["step_4_python_pandas"]
+    assert list(implementation_graph.edges) == []
 
     # Test implementation_graph for substeps
     step_config = LayeredConfigTree(
@@ -209,8 +209,8 @@ def test_hierarchical_step_implementation_graph(
         }
     )
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == [
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == [
         "step_4a_python_pandas",
         "step_4b_python_pandas",
     ]
@@ -229,9 +229,9 @@ def test_hierarchical_step_implementation_graph(
             },
         ),
     ]
-    assert len(subgraph.edges) == len(expected_edges)
+    assert len(implementation_graph.edges) == len(expected_edges)
     for edge in expected_edges:
-        assert edge in subgraph.edges(data=True)
+        assert edge in implementation_graph.edges(data=True)
 
 
 @pytest.fixture
@@ -363,9 +363,9 @@ def test_loop_implementation_graph(
     mocker.patch("easylink.implementation.Implementation.validate", return_value=[])
     step = LoopStep(**loop_step_params)
     step.set_configuration_state(default_config["pipeline"]["steps"][step.name], {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == ["step_3_python_pandas"]
-    assert list(subgraph.edges) == []
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == ["step_3_python_pandas"]
+    assert list(implementation_graph.edges) == []
 
     step_config = LayeredConfigTree(
         {
@@ -396,8 +396,8 @@ def test_loop_implementation_graph(
         },
     )
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == [
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == [
         "step_3_loop_1_step_3_python_pandas",
         "step_3_loop_2_step_3a_step_3a_python_pandas",
         "step_3_loop_2_step_3b_step_3b_python_pandas",
@@ -430,9 +430,9 @@ def test_loop_implementation_graph(
             },
         ),
     ]
-    assert len(subgraph.edges) == len(expected_edges)
+    assert len(implementation_graph.edges) == len(expected_edges)
     for edge in expected_edges:
-        assert edge in subgraph.edges(data=True)
+        assert edge in implementation_graph.edges(data=True)
 
 
 @pytest.fixture
@@ -569,8 +569,8 @@ def test_parallel_step_implementation_graph(
         },
     )
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert set(subgraph.nodes) == {
+    implementation_graph = _create_implementation_graph(step)
+    assert set(implementation_graph.nodes) == {
         "step_1_parallel_split_1_step_1a_step_1a_python_pandas",
         "step_1_parallel_split_1_step_1b_step_1b_python_pandas",
         "step_1_parallel_split_2_step_1a_step_1a_python_pandas",
@@ -619,9 +619,9 @@ def test_parallel_step_implementation_graph(
             },
         ),
     ]
-    assert len(subgraph.edges) == len(expected_edges)
+    assert len(implementation_graph.edges) == len(expected_edges)
     for edge in expected_edges:
-        assert edge in subgraph.edges(data=True)
+        assert edge in implementation_graph.edges(data=True)
 
 
 @pytest.mark.parametrize("step_type", ["parallel", "loop"])
@@ -654,8 +654,8 @@ def test_templated_implementation_graph_no_multiplicity(
         },
     )
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert set(subgraph.nodes) == {
+    implementation_graph = _create_implementation_graph(step)
+    assert set(implementation_graph.nodes) == {
         f"{step.name}a_python_pandas",
         f"{step.name}b_python_pandas",
     }
@@ -674,9 +674,9 @@ def test_templated_implementation_graph_no_multiplicity(
             },
         ),
     ]
-    assert len(subgraph.edges) == len(expected_edges)
+    assert len(implementation_graph.edges) == len(expected_edges)
     for edge in expected_edges:
-        assert edge in subgraph.edges(data=True)
+        assert edge in implementation_graph.edges(data=True)
 
 
 @pytest.mark.parametrize("step_type", ["loop", "parallel"])
@@ -983,9 +983,9 @@ def test_simple_choice_step_implementation_graph(choice_step_params: dict[str, A
     # Need to validate in order to set the step graph an mappings prior to calling `set_configuration_state`
     step.validate_step(step_config, {}, {})
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == ["step_4_python_pandas"]
-    assert list(subgraph.edges) == []
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == ["step_4_python_pandas"]
+    assert list(implementation_graph.edges) == []
 
     # Test implementation_graph for a step with substeps
     step_config = LayeredConfigTree(
@@ -1008,8 +1008,8 @@ def test_simple_choice_step_implementation_graph(choice_step_params: dict[str, A
         }
     )
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == [
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == [
         "step_4a_python_pandas",
         "step_4b_r",
     ]
@@ -1028,9 +1028,9 @@ def test_simple_choice_step_implementation_graph(choice_step_params: dict[str, A
             },
         ),
     ]
-    assert len(subgraph.edges) == len(expected_edges)
+    assert len(implementation_graph.edges) == len(expected_edges)
     for edge in expected_edges:
-        assert edge in subgraph.edges(data=True)
+        assert edge in implementation_graph.edges(data=True)
 
 
 def test_complex_choice_step_implementation_graph(choice_step_params: dict[str, Any]) -> None:
@@ -1067,8 +1067,8 @@ def test_complex_choice_step_implementation_graph(choice_step_params: dict[str, 
     # Need to validate in order to set the step graph and mappings prior to calling `set_configuration_state`
     step.validate_step(step_config, {}, {})
     step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
-    assert list(subgraph.nodes) == [
+    implementation_graph = _create_implementation_graph(step)
+    assert list(implementation_graph.nodes) == [
         "step_5_python_pandas",
         "step_6_loop_1_step_6_python_pandas",
         "step_6_loop_2_step_6_python_pandas",
@@ -1101,9 +1101,9 @@ def test_complex_choice_step_implementation_graph(choice_step_params: dict[str, 
             },
         ),
     ]
-    assert len(subgraph.edges) == len(expected_edges)
+    assert len(implementation_graph.edges) == len(expected_edges)
     for edge in expected_edges:
-        assert edge in subgraph.edges(data=True)
+        assert edge in implementation_graph.edges(data=True)
 
 
 @pytest.fixture
@@ -1160,18 +1160,18 @@ def test_embarrassingly_parallel_step_implementation_graph(
     embarrassingly_parallel_step_params: dict[str, Any]
 ) -> None:
     ep_step = EmbarrassinglyParallelStep(**embarrassingly_parallel_step_params)
-    step_config = LayeredConfigTree(
-        {"implementation": {"name": "step_3_python_pandas", "configuration": {}}}
-    )
+    step_config = LayeredConfigTree({"implementation": {"name": "step_3_python_pandas"}})
     ep_step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(ep_step)
-    assert list(subgraph.nodes) == ["step_3_python_pandas"]
-    assert list(subgraph.edges) == []
+    implementation_graph = _create_implementation_graph(ep_step)
+    assert list(implementation_graph.nodes) == ["step_3_python_pandas"]
+    assert list(implementation_graph.edges) == []
 
     # Check that the implementation has the splitter and aggregator
-    implementation = subgraph.nodes["step_3_python_pandas"]["implementation"]
+    implementation = implementation_graph.nodes["step_3_python_pandas"]["implementation"]
     assert implementation.input_slots["step_3_main_input"].splitter == split_data_by_size
-    assert implementation.output_slots["step_3_main_output"].aggregator == concatenate_datasets
+    assert (
+        implementation.output_slots["step_3_main_output"].aggregator == concatenate_datasets
+    )
 
 
 @pytest.mark.parametrize(
@@ -1438,34 +1438,57 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
     }
 
 
-def test_embarrassingly_parallel_step__propagate_splitter_aggregators(
+def test_embarrassingly_parallel_hierarchical_step_implementation_graph(
     embarrassingly_parallel_hierarchical_step_params,
 ) -> None:
-    step = EmbarrassinglyParallelStep(**embarrassingly_parallel_hierarchical_step_params)
-    EmbarrassinglyParallelStep._propagate_splitter_aggregators(step)
+    ep_step = EmbarrassinglyParallelStep(**embarrassingly_parallel_hierarchical_step_params)
+    step_config = LayeredConfigTree(
+        {
+            "substeps": {
+                "step_1": {"implementation": {"name": "step_1_python_pandas"}},
+                "step_2": {"implementation": {"name": "step_2_python_pandas"}},
+                "step_3": {"implementation": {"name": "step_3_python_pandas"}},
+            },
+        }
+    )
+    ep_step.set_configuration_state(step_config, {}, {})
+    implementation_graph = _create_implementation_graph(ep_step)
+    assert list(implementation_graph.nodes) == [
+        "step_1_python_pandas",
+        "step_2_python_pandas",
+        "step_3_python_pandas",
+    ]
+    assert list(implementation_graph.edges) == [
+        ("step_1_python_pandas", "step_2_python_pandas", 0),
+        ("step_1_python_pandas", "step_2_python_pandas", 1),
+        ("step_2_python_pandas", "step_3_python_pandas", 0),
+        ("step_2_python_pandas", "step_3_python_pandas", 1),
+    ]
 
-    step1 = step.step.step_graph.nodes["step_1"]["step"]
-    assert step1.input_slots["step_1_main_input"].splitter == split_data_by_size
-    assert step1.input_slots["step_1_secondary_input"].splitter == None
-    assert step1.output_slots["step_1_main_output"].aggregator == None
-    assert step1.output_slots["step_1_secondary_output"].aggregator == None
+    # Check that the implementation has the splitter and aggregator
+    imp1 = implementation_graph.nodes["step_1_python_pandas"]["implementation"]
+    assert imp1.input_slots["step_1_main_input"].splitter == split_data_by_size
+    assert imp1.input_slots["step_1_secondary_input"].splitter == None
+    assert imp1.output_slots["step_1_main_output"].aggregator == None
+    assert imp1.output_slots["step_1_secondary_output"].aggregator == None
 
-    step2 = step.step.step_graph.nodes["step_2"]["step"]
-    assert step2.input_slots["step_2_main_input"].splitter == None
-    assert step2.input_slots["step_2_secondary_input"].splitter == None
-    assert step2.output_slots["step_2_main_output"].aggregator == None
-    assert step2.output_slots["step_2_secondary_output"].aggregator == None
+    imp2 = implementation_graph.nodes["step_2_python_pandas"]["implementation"]
+    assert imp2.input_slots["step_2_main_input"].splitter == None
+    assert imp2.input_slots["step_2_secondary_input"].splitter == None
+    assert imp2.output_slots["step_2_main_output"].aggregator == None
+    assert imp2.output_slots["step_2_secondary_output"].aggregator == None
 
-    step3 = step.step.step_graph.nodes["step_3"]["step"]
-    assert step3.input_slots["step_3_main_input"].splitter == None
-    assert step3.input_slots["step_3_secondary_input"].splitter == None
-    assert step3.output_slots["step_3_main_output"].aggregator == concatenate_datasets
-    assert step3.output_slots["step_3_secondary_output"].aggregator == concatenate_datasets
+    imp3 = implementation_graph.nodes["step_3_python_pandas"]["implementation"]
+    assert imp3.input_slots["step_3_main_input"].splitter == None
+    assert imp3.input_slots["step_3_secondary_input"].splitter == None
+    assert imp3.output_slots["step_3_main_output"].aggregator == concatenate_datasets
+    assert imp3.output_slots["step_3_secondary_output"].aggregator == concatenate_datasets
 
 
 ####################
 # Helper functions #
 ####################
+
 
 def _create_implementation_graph(step: Step) -> ImplementationGraph:
     implementation_graph = ImplementationGraph()

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1172,6 +1172,7 @@ def test_embarrassingly_parallel_step_implementation_graph(
     assert (
         implementation.output_slots["step_3_main_output"].aggregator == concatenate_datasets
     )
+    assert implementation.is_embarrassingly_parallel
 
 
 @pytest.mark.parametrize(
@@ -1471,18 +1472,21 @@ def test_embarrassingly_parallel_hierarchical_step_implementation_graph(
     assert imp1.input_slots["step_1_secondary_input"].splitter == None
     assert imp1.output_slots["step_1_main_output"].aggregator == None
     assert imp1.output_slots["step_1_secondary_output"].aggregator == None
+    assert imp1.is_embarrassingly_parallel
 
     imp2 = implementation_graph.nodes["step_2_python_pandas"]["implementation"]
     assert imp2.input_slots["step_2_main_input"].splitter == None
     assert imp2.input_slots["step_2_secondary_input"].splitter == None
     assert imp2.output_slots["step_2_main_output"].aggregator == None
     assert imp2.output_slots["step_2_secondary_output"].aggregator == None
+    assert imp2.is_embarrassingly_parallel
 
     imp3 = implementation_graph.nodes["step_3_python_pandas"]["implementation"]
     assert imp3.input_slots["step_3_main_input"].splitter == None
     assert imp3.input_slots["step_3_secondary_input"].splitter == None
     assert imp3.output_slots["step_3_main_output"].aggregator == concatenate_datasets
     assert imp3.output_slots["step_3_secondary_output"].aggregator == concatenate_datasets
+    assert imp3.is_embarrassingly_parallel
 
 
 ####################

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1164,7 +1164,7 @@ def test_embarrassingly_parallel_step_implementation_graph(
         {"implementation": {"name": "step_3_python_pandas", "configuration": {}}}
     )
     ep_step.set_configuration_state(step_config, {}, {})
-    subgraph = _create_implementation_graph(step)
+    subgraph = _create_implementation_graph(ep_step)
     assert list(subgraph.nodes) == ["step_3_python_pandas"]
     assert list(subgraph.edges) == []
 

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1122,18 +1122,18 @@ def embarrassingly_parallel_step_params() -> dict[str, Any]:
         ),
         "input_slots": [
             InputSlot(
-                "step_3ep_main_input",
+                "ep_step_3_main_input",
                 "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
                 split_data_by_size,
             )
         ],
-        "output_slots": [OutputSlot("step_3ep_main_output", concatenate_datasets)],
+        "output_slots": [OutputSlot("ep_step_3_main_output", concatenate_datasets)],
         "input_slot_mappings": [
-            InputSlotMapping("step_3ep_main_input", "step_3", "step_3_main_input")
+            InputSlotMapping("ep_step_3_main_input", "step_3", "step_3_main_input")
         ],
         "output_slot_mappings": [
-            OutputSlotMapping("step_3ep_main_output", "step_3", "step_3_main_output")
+            OutputSlotMapping("ep_step_3_main_output", "step_3", "step_3_main_output")
         ],
     }
 
@@ -1144,15 +1144,15 @@ def test_embarrassingly_parallel_step_slots(
     step = EmbarrassinglyParallelStep(**embarrassingly_parallel_step_params)
     assert step.name == "step_3"
     assert step.input_slots == {
-        "step_3ep_main_input": InputSlot(
-            "step_3ep_main_input",
+        "ep_step_3_main_input": InputSlot(
+            "ep_step_3_main_input",
             "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
             validate_input_file_dummy,
             split_data_by_size,
         ),
     }
     assert step.output_slots == {
-        "step_3ep_main_output": OutputSlot("step_3ep_main_output", concatenate_datasets),
+        "ep_step_3_main_output": OutputSlot("ep_step_3_main_output", concatenate_datasets),
     }
 
 
@@ -1296,10 +1296,175 @@ def test_embarrassingly_parallel_step__validation(
         assert msg in error_msg
 
 
+@pytest.fixture
+def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
+    return {
+        "step": HierarchicalStep(
+            step_name="steps_1_2_3",
+            input_slots=[
+                InputSlot(
+                    "steps_1_2_3_main_input",
+                    "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validate_input_file_dummy,
+                ),
+                InputSlot(
+                    "steps_1_2_3_secondary_input",
+                    "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validate_input_file_dummy,
+                ),
+            ],
+            output_slots=[
+                OutputSlot("steps_1_2_3_main_output"),
+                OutputSlot("steps_1_2_3_secondary_output"),
+            ],
+            nodes=[
+                Step(
+                    "step_1",
+                    input_slots=[
+                        InputSlot(
+                            "step_1_main_input",
+                            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                            validate_input_file_dummy,
+                        ),
+                        InputSlot(
+                            "step_1_secondary_input",
+                            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                            validate_input_file_dummy,
+                        ),
+                    ],
+                    output_slots=[
+                        OutputSlot("step_1_main_output"),
+                        OutputSlot("step_1_secondary_output"),
+                    ],
+                ),
+                Step(
+                    "step_2",
+                    input_slots=[
+                        InputSlot(
+                            "step_2_main_input",
+                            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                            validate_input_file_dummy,
+                        ),
+                        InputSlot(
+                            "step_2_secondary_input",
+                            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                            validate_input_file_dummy,
+                        ),
+                    ],
+                    output_slots=[
+                        OutputSlot("step_2_main_output"),
+                        OutputSlot("step_2_secondary_output"),
+                    ],
+                ),
+                Step(
+                    "step_3",
+                    input_slots=[
+                        InputSlot(
+                            "step_3_main_input",
+                            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                            validate_input_file_dummy,
+                        ),
+                        InputSlot(
+                            "step_3_secondary_input",
+                            "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                            validate_input_file_dummy,
+                        ),
+                    ],
+                    output_slots=[
+                        OutputSlot("step_3_main_output"),
+                        OutputSlot("step_3_secondary_output"),
+                    ],
+                ),
+            ],
+            edges=[
+                EdgeParams("step_1", "step_2", "step_1_main_output", "step_2_main_input"),
+                EdgeParams(
+                    "step_1", "step_2", "step_1_secondary_output", "step_2_secondary_input"
+                ),
+                EdgeParams("step_2", "step_3", "step_2_main_output", "step_3_main_input"),
+                EdgeParams(
+                    "step_2", "step_3", "step_2_secondary_output", "step_3_secondary_input"
+                ),
+            ],
+            input_slot_mappings=[
+                InputSlotMapping("steps_1_2_3_main_input", "step_1", "step_1_main_input"),
+                InputSlotMapping(
+                    "steps_1_2_3_secondary_input", "step_1", "step_1_secondary_input"
+                ),
+            ],
+            output_slot_mappings=[
+                OutputSlotMapping("steps_1_2_3_main_output", "step_3", "step_3_main_output"),
+                OutputSlotMapping(
+                    "steps_1_2_3_secondary_output", "step_3", "step_3_secondary_output"
+                ),
+            ],
+        ),
+        "input_slots": [
+            InputSlot(
+                "ep_steps_1_2_3_main_input",
+                "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                validate_input_file_dummy,
+                split_data_by_size,
+            ),
+            InputSlot(
+                "ep_steps_1_2_3_secondary_input",
+                "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                validate_input_file_dummy,
+            ),
+        ],
+        "output_slots": [
+            OutputSlot("ep_steps_1_2_3_main_output", concatenate_datasets),
+            OutputSlot("ep_steps_1_2_3_secondary_output", concatenate_datasets),
+        ],
+        "input_slot_mappings": [
+            InputSlotMapping(
+                "ep_steps_1_2_3_main_input", "steps_1_2_3", "steps_1_2_3_main_input"
+            ),
+            InputSlotMapping(
+                "ep_steps_1_2_3_secondary_input", "steps_1_2_3", "steps_1_2_3_secondary_input"
+            ),
+        ],
+        "output_slot_mappings": [
+            OutputSlotMapping(
+                "ep_steps_1_2_3_main_output", "steps_1_2_3", "steps_1_2_3_main_output"
+            ),
+            OutputSlotMapping(
+                "ep_steps_1_2_3_secondary_output",
+                "steps_1_2_3",
+                "steps_1_2_3_secondary_output",
+            ),
+        ],
+    }
+
+
+def test_embarrassingly_parallel_step__propagate_splitter_aggregators(
+    embarrassingly_parallel_hierarchical_step_params,
+) -> None:
+    step = EmbarrassinglyParallelStep(**embarrassingly_parallel_hierarchical_step_params)
+    EmbarrassinglyParallelStep._propagate_splitter_aggregators(step)
+
+    step1 = step.step.step_graph.nodes["step_1"]["step"]
+    assert step1.input_slots["step_1_main_input"].splitter == split_data_by_size
+    assert step1.input_slots["step_1_secondary_input"].splitter == None
+    assert step1.output_slots["step_1_main_output"].aggregator == None
+    assert step1.output_slots["step_1_secondary_output"].aggregator == None
+
+    step2 = step.step.step_graph.nodes["step_2"]["step"]
+    assert step2.input_slots["step_2_main_input"].splitter == None
+    assert step2.input_slots["step_2_secondary_input"].splitter == None
+    assert step2.output_slots["step_2_main_output"].aggregator == None
+    assert step2.output_slots["step_2_secondary_output"].aggregator == None
+
+    step3 = step.step.step_graph.nodes["step_3"]["step"]
+    assert step3.input_slots["step_3_main_input"].splitter == None
+    assert step3.input_slots["step_3_secondary_input"].splitter == None
+    assert step3.output_slots["step_3_main_output"].aggregator == concatenate_datasets
+    assert step3.output_slots["step_3_secondary_output"].aggregator == concatenate_datasets
+
+
 ####################
 # Helper functions #
 ####################
-
 
 def _create_implementation_graph(step: Step) -> ImplementationGraph:
     implementation_graph = ImplementationGraph()


### PR DESCRIPTION
## Properly propagate embarrassingly parallel splitters and aggregators

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5947
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> The (currently) one and only use of an EmbarrassinglyParallelStep
made use of a basic `Step` as the step to run in parallel. Because of that,
it is trivial to just assign the splitter and aggregator to that step.

This properly maps the EmbarrassinglyParallelStep's splitter and
aggregators (which reside on InputSlots and OutputSlots, respectively)
to the underlying leaf steps.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
added a new test; existing pass

