### PR TITLE
refactor recursion for clarity

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.11 - 3/27/25**
+
+ - Refactor the ImplementationGraph recursion logic for clarity
+
 **0.1.10 - 3/25/25**
 
  - Make InputSlots and OutputSlots mutable

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.1.11 - 3/27/25**
+**0.1.11 - 3/28/25**
 
  - Refactor the ImplementationGraph recursion logic for clarity
 

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -61,8 +61,8 @@ class PipelineSchema(HierarchicalStep):
         which has a :class:`~easylink.graph_components.StepGraph` containing
         sub-:class:`Steps<easylink.step.Step>` that need to be unrolled. This method
         recursively traverses that ``StepGraph`` and its childrens' ``StepGraphs``
-        until all sub-``Steps`` are in a :class:`~easylink.step.LeafConfigurationState`, 
-        i.e. all ``Steps`` are implemented by a single ``Implementation`` and we 
+        until all sub-``Steps`` are in a :class:`~easylink.step.LeafConfigurationState`,
+        i.e. all ``Steps`` are implemented by a single ``Implementation`` and we
         have the desired ``ImplementationGraph``.
 
         Returns

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from layered_config_tree import LayeredConfigTree
 
-from easylink.graph_components import EdgeParams
+from easylink.graph_components import EdgeParams, ImplementationGraph
 from easylink.pipeline_schema_constants import ALLOWED_SCHEMA_PARAMS
 from easylink.step import HierarchicalStep, NonLeafConfigurationState, Step
 
@@ -53,6 +53,26 @@ class PipelineSchema(HierarchicalStep):
 
     def __repr__(self) -> str:
         return f"PipelineSchema.{self.name}"
+
+    def get_implementation_graph(self) -> ImplementationGraph:
+        """Gets the :class:`~easylink.graph_components.ImplementationGraph`.
+
+        The ``PipelineSchema`` is by definition a :class:`~easylink.step.HierarchicalStep`
+        which has a :class:`~easylink.graph_components.StepGraph` containing
+        sub-:class:`Steps<easylink.step.Step>` that need to be unrolled. This method
+        recursively traverses that ``StepGraph`` and its childrens' ``StepGraphs``
+        until all sub-``Steps`` are in a :class:`~easylink.step.LeafConfigurationState`, 
+        i.e. all ``Steps`` are implemented by a single ``Implementation`` and we 
+        have the desired ``ImplementationGraph``.
+
+        Returns
+        -------
+            The ``ImplementationGraph`` of this ``PipelineSchema``.
+        """
+        implementation_graph = ImplementationGraph()
+        self.add_nodes_to_implementation_graph(implementation_graph)
+        self.add_edges_to_implementation_graph(implementation_graph)
+        return implementation_graph
 
     def validate_step(
         self, pipeline_config: LayeredConfigTree, input_data_config: LayeredConfigTree

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -423,7 +423,8 @@ class IOStep(Step):
     def add_edges_to_implementation_graph(self, implementation_graph):
         """Adds the edges of this ``Step's`` ``Implementation`` to the ``ImplementationGraph``.
 
-        ``IOSteps`` do not have edges in the ``ImplementationGraph`` and so we
+        ``IOSteps`` do not have edges within them in the ``ImplementationGraph``,
+        since they are represented by a single ``NullImplementation`` node, and so we
         simply pass.
         """
         pass

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1634,6 +1634,11 @@ class NonLeafConfigurationState(ConfigurationState):
         ``NonLeafConfigurationState``) to the ``ImplementationGraph``.
         2. Recursively traverses all sub-steps and adds their edges to the
         ``ImplementationGraph``.
+        
+        Note that to achieve (1), edges must be mapped from being between steps at
+        this level of the hierarchy, all the way down to being between concrete implementations.
+        Mapping each edge down to the implementation level is *itself* a recursive
+        operation (see ``get_implementation_edges``).
         """
         # Add the edges at this level (i.e. the edges at this `self._step`)
         for source, target, edge_attrs in self._step.step_graph.edges(data=True):

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1634,7 +1634,7 @@ class NonLeafConfigurationState(ConfigurationState):
         ``NonLeafConfigurationState``) to the ``ImplementationGraph``.
         2. Recursively traverses all sub-steps and adds their edges to the
         ``ImplementationGraph``.
-        
+
         Note that to achieve (1), edges must be mapped from being between steps at
         this level of the hierarchy, all the way down to being between concrete implementations.
         Mapping each edge down to the implementation level is *itself* a recursive
@@ -1657,12 +1657,16 @@ class NonLeafConfigurationState(ConfigurationState):
             substep.add_edges_to_implementation_graph(implementation_graph)
 
     def get_implementation_edges(self, edge: EdgeParams) -> list[EdgeParams]:
-        """Gets the edge information for the ``Implementation`` related to this ``Step``.
+        """Gets the edges for the ``Implementation`` related to this ``Step``.
+
+        This method maps an edge between ``Steps`` in this ``Step's`` ``StepGraph``
+        to one or more edges between ``Implementations`` by applying ``SlotMappings``.
 
         Parameters
         ----------
         edge
-            The ``Step's`` edge information to be propagated to the ``ImplementationGraph``.
+            The edge information of the edge in the ``StepGraph`` to be mapped to
+            the ``Implementation`` level.
 
         Raises
         ------
@@ -1671,7 +1675,28 @@ class NonLeafConfigurationState(ConfigurationState):
 
         Returns
         -------
-            The ``Implementation's`` edge information.
+            A list of edges between ``Implementations`` which are ready to add to
+            the ``ImplementationGraph``.
+
+        Notes
+        -----
+        In EasyLink, an edge (in either a ``StepGraph`` or ``ImplementationGraph``)
+        sconnects two ``Slot``.
+
+        The core of this method is to map the ``Slots`` on the ``StepGraph`` edge
+        to the corresponding ``Slots`` on ``Implementations``.
+
+        At each level in the step hierarchy, ``SlotMappings`` indicate how to map
+        a ``Slot`` to the level below in the hierarchy.
+
+        This method recurses through the step hierarchy until it reaches the leaf
+        ``Steps`` relevant to this edge in order to compose all the ``SlotMappings``
+        that should apply to it.
+
+        Because a single ``Step`` can become multiple nodes in the ``ImplementationGraph``
+        (e.g. a :class:`TemplatedStep`), a single edge between ``Steps`` may actually
+        become multiple edges between ``Implementations``, which is why this method
+        can return a list.
         """
         implementation_edges = []
         if edge.source_node == self._step.name:

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1496,7 +1496,8 @@ class LeafConfigurationState(ConfigurationState):
     def add_edges_to_implementation_graph(self, implementation_graph) -> None:
         """Adds the edges for this ``Step's`` ``Implementation`` to the ``ImplementationGraph``.
 
-        ``Steps`` in a ``LeafConfigurationState`` do not actually have edges and so
+        ``Steps`` in a ``LeafConfigurationState`` do not actually have edges within them
+        (they are represented by a single node in the ``ImplementationGraph``) and so
         we simply pass.
         """
         pass


### PR DESCRIPTION
## Refactor ImplementationGraph recursion logic for clarity.

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5953
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This does two main things to help with recursion during the building of the
ImplementationGraph
1. It fully separates the recursive node-adding from the recursive edge-adding.
2. It slips the order of the edge-adding for a non-leaf Step.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

