### PR TITLE
Add a new custom-schema integration test

### DIFF
--- a/src/easylink/configuration.py
+++ b/src/easylink/configuration.py
@@ -274,10 +274,10 @@ class Config(LayeredConfigTree):
 
 
 def load_params_from_specification(
-    pipeline_specification: str,
-    input_data: str,
-    computing_environment: str | None,
-    results_dir: str,
+    pipeline_specification: str | Path,
+    input_data: str | Path,
+    computing_environment: str | Path | None,
+    results_dir: str | Path,
 ) -> dict[str, Any]:
     """Gathers together all specification data.
 
@@ -325,7 +325,7 @@ def _load_input_data_paths(
 
 
 def _load_computing_environment(
-    computing_environment_specification_path: str | None,
+    computing_environment_specification_path: str | Path | None,
 ) -> dict[Any, Any]:
     """Loads the computing environment specification file and returns the contents as a dict."""
     if not computing_environment_specification_path:

--- a/src/easylink/pipeline_schema_constants/__init__.py
+++ b/src/easylink/pipeline_schema_constants/__init__.py
@@ -23,4 +23,5 @@ TESTING_SCHEMA_PARAMS = {
     "combine_with_iteration": testing.COMBINE_WITH_ITERATION_SCHEMA_PARAMS,
     "combine_with_iteration_cycle": testing.COMBINE_WITH_ITERATION_SCHEMA_PARAMS,
     "combine_with_extra_node": testing.TRIPLE_STEP_SCHEMA_PARAMS,
+    "looping_ep_step": testing.LOOPING_EP_STEP_SCHEMA_PARAMS,
 }

--- a/src/easylink/utilities/splitter_utils.py
+++ b/src/easylink/utilities/splitter_utils.py
@@ -70,3 +70,38 @@ def split_data_by_size(
             f"{chunk.index[-1]})"
         )
         chunk.to_parquet(os.path.join(chunk_dir, "result.parquet"))
+
+
+def split_data_in_two(input_files: list[str], output_dir: str, *args, **kwargs) -> None:
+    """Splits the data (from a single input slot) into two chunks of equal.
+
+    This function takes all datasets from a single input slot, concatenates them,
+    and then splits the resulting dataset into two chunks of similar size.
+
+    Parameters
+    ----------
+    input_files
+        A list of input file paths to be concatenated and split.
+    output_dir
+        The directory where the resulting chunks will be saved.
+    desired_chunk_size_mb
+        The desired size of each chunk, in megabytes.
+    """
+
+    # concatenate all input files
+    df = pd.DataFrame()
+    for file in input_files:
+        tmp = pd.read_parquet(file)
+        df = pd.concat([df, tmp], ignore_index=True)
+
+    # divide df into two and save each chunk out
+    num_chunks = 2
+    chunk_size = math.ceil(len(df) / num_chunks)
+    for i in range(num_chunks):
+        start = i * chunk_size
+        end = (i + 1) * chunk_size
+        chunk = df.iloc[start:end]
+        chunk_dir = os.path.join(output_dir, f"chunk_{i}")
+        if not os.path.exists(chunk_dir):
+            os.makedirs(chunk_dir)
+        chunk.to_parquet(os.path.join(chunk_dir, "result.parquet"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def test_specific_results_dir():
     results_dir = Path(results_dir)
     yield results_dir
 
-    # Try 10 to delete the dir.
+    # Try 10 times to delete the dir.
     # NOTE: There seems to be times where the directory is not removed (even after
     # the several attempts with a rest between them). Typically the dir is empty.
     for _ in range(10):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 # mypy: ignore-errors
+import os
+import tempfile
+import time
 from pathlib import Path
+from shutil import rmtree
 
 import pytest
 from _pytest.logging import LogCaptureFixture
@@ -38,3 +42,34 @@ def caplog(caplog: LogCaptureFixture):
     )
     yield caplog
     logger.remove(handler_id)
+
+
+@pytest.fixture
+def test_specific_results_dir():
+    """Creates a temporary and unique directory for each test to store results.
+
+    This fixture yields the path for the test to use and then cleans up the directory
+    after the test is done.
+
+    Notes
+    -----
+    We cannot use pytest's tmp_path fixture because other nodes do not have access to it.
+    Also, do not use a context manager (i.e. tempfile.TemporaryDirectory) because it's too
+    difficult to debug when the test fails b/c the dir gets deleted.
+    """
+    results_dir = tempfile.mkdtemp(dir=RESULTS_DIR)
+    # give the dir the same permissions as the parent directory so that cluster jobs
+    # can write to it
+    os.chmod(results_dir, os.stat(RESULTS_DIR).st_mode)
+    results_dir = Path(results_dir)
+    yield results_dir
+
+    # Try 10 to delete the dir.
+    # NOTE: There seems to be times where the directory is not removed (even after
+    # the several attempts with a rest between them). Typically the dir is empty.
+    for _ in range(10):
+        if not results_dir.exists():
+            break  # the dir has been removed
+        # Take a quick nap to ensure processes are finished with the directory
+        time.sleep(1)
+        rmtree(results_dir)

--- a/tests/e2e/test_step_types.py
+++ b/tests/e2e/test_step_types.py
@@ -1,12 +1,10 @@
 # mypy: ignore-errors
 import subprocess
 import sys
-import tempfile
-from pathlib import Path
 
 import pytest
 
-from tests.conftest import RESULTS_DIR, SPECIFICATIONS_DIR
+from tests.conftest import SPECIFICATIONS_DIR
 
 
 @pytest.mark.slow
@@ -39,23 +37,17 @@ from tests.conftest import RESULTS_DIR, SPECIFICATIONS_DIR
         ),
     ],
 )
-def test_step_types(pipeline_specification, implementations, capsys):
+def test_step_types(
+    pipeline_specification, implementations, test_specific_results_dir, capsys
+):
     """Tests against various permutations of complex step types.
 
     The goal is to test that EasyLink generates the correct output implementations
     depending on the configuration; i.e. if we have a 'substeps' key in the config,
     we get an implementation for each (or else we get a single implementation).
     """
-    # Create a temporary directory to store results. We cannot use pytest's tmp_path fixture
-    # because other nodes do not have access to it. Also, do not use a context manager
-    # (i.e. tempfile.TemporaryDirectory) because it's too difficult to debug when the test
-    # fails b/c the dir gets deleted.
-    results_dir = tempfile.mkdtemp(dir=RESULTS_DIR)
     input_data = "common/input_data.yaml"
     computing_environment = "common/environment_local.yaml"
-    # give the tmpdir the same permissions as the parent directory so that
-    # cluster jobs can write to it
-    results_dir = Path(results_dir)
     with capsys.disabled():  # disabled so we can monitor job submissions
         print("\n\n*** RUNNING TEST ***\n" f"[{pipeline_specification}]\n")
 
@@ -64,7 +56,7 @@ def test_step_types(pipeline_specification, implementations, capsys):
             f"-p {SPECIFICATIONS_DIR / pipeline_specification} "
             f"-i {SPECIFICATIONS_DIR / input_data} "
             f"-e {SPECIFICATIONS_DIR / computing_environment} "
-            f"-o {str(results_dir)} "
+            f"-o {str(test_specific_results_dir)} "
             "--no-timestamp"
         )
         subprocess.run(
@@ -74,12 +66,14 @@ def test_step_types(pipeline_specification, implementations, capsys):
             stderr=sys.stderr,
             check=True,
         )
-        final_output = results_dir / "result.parquet"
+        final_output = test_specific_results_dir / "result.parquet"
         assert final_output.exists()
 
         # Check that we get directories for particular implementations
-        diagnostics_dir = results_dir / "diagnostics"
+        diagnostics_dir = test_specific_results_dir / "diagnostics"
         for implementation in implementations:
             assert (diagnostics_dir / implementation).exists()
-            assert (results_dir / "intermediate" / implementation / "result.parquet").exists()
+            assert (
+                test_specific_results_dir / "intermediate" / implementation / "result.parquet"
+            ).exists()
         print("\n\n*** END OF TEST ***\n" f"[{pipeline_specification}]\n")

--- a/tests/integration/test_compositions.py
+++ b/tests/integration/test_compositions.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+
+from easylink.pipeline_schema import PipelineSchema
+from easylink.pipeline_schema_constants import TESTING_SCHEMA_PARAMS
+from easylink.runner import main
+from tests.conftest import SPECIFICATIONS_DIR
+
+COMMON_SPECIFICATIONS_DIR = SPECIFICATIONS_DIR / "common"
+EP_SPECIFICATIONS_DIR = SPECIFICATIONS_DIR / "integration" / "embarrassingly_parallel"
+
+
+@pytest.mark.slow
+def test_looping_embarrassingly_parallel_step(test_specific_results_dir: Path):
+    pipeline_specification = EP_SPECIFICATIONS_DIR / "pipeline_loop_step.yaml"
+    input_data = COMMON_SPECIFICATIONS_DIR / "input_data.yaml"
+
+    # Load the schema to test against
+    schema = PipelineSchema("looping_ep_step", *TESTING_SCHEMA_PARAMS["looping_ep_step"])
+
+    # Run the pipeline. Snakemake will exit at the end so we need to catch that here
+    _run_pipeline(schema, test_specific_results_dir, pipeline_specification, input_data)
+
+    for loop in [1, 2]:
+        implementation = f"step_1_loop_{loop}_step_1_python_pandas"
+        implementation_subdir = test_specific_results_dir / "intermediate" / implementation
+        # ensure that the input was split into two
+        assert (
+            len(list((implementation_subdir / "input_chunks").rglob("result.parquet"))) == 2
+        )
+        # ensure that each chunk was processed individually
+        assert len(list((implementation_subdir / "processed").rglob("result.parquet"))) == 2
+        # check for aggregated file
+        assert (implementation_subdir / "result.parquet").exists()
+
+
+####################
+# Helper Functions #
+####################
+
+
+def _run_pipeline(
+    schema: PipelineSchema,
+    results_dir: Path,
+    pipeline_specification: Path,
+    input_data: Path,
+    computing_environment: Path | None = None,
+):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        main(
+            command="run",
+            pipeline_specification=pipeline_specification,
+            input_data=input_data,
+            computing_environment=computing_environment,
+            results_dir=results_dir,
+            potential_schemas=schema,
+        )
+    assert pytest_wrapped_e.value.code == 0
+
+    assert (results_dir / "result.parquet").exists()
+    assert (results_dir / pipeline_specification.name).exists()
+    assert (results_dir / input_data.name).exists()
+    if computing_environment:
+        assert (results_dir / computing_environment.name).exists()

--- a/tests/integration/test_snakemake.py
+++ b/tests/integration/test_snakemake.py
@@ -1,17 +1,14 @@
 # mypy: ignore-errors
-import os
-import tempfile
-
 import pytest
 
 from easylink.pipeline_schema import PipelineSchema
 from easylink.pipeline_schema_constants import TESTING_SCHEMA_PARAMS
 from easylink.runner import main
-from tests.conftest import RESULTS_DIR, SPECIFICATIONS_DIR
+from tests.conftest import SPECIFICATIONS_DIR
 
 
 @pytest.mark.slow
-def test_missing_results(mocker, caplog):
+def test_missing_results(test_specific_results_dir, mocker, caplog):
     """Test that the pipeline fails when a step is missing output files."""
     nodes, edges = TESTING_SCHEMA_PARAMS["integration"]
     mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
@@ -26,17 +23,13 @@ def test_missing_results(mocker, caplog):
         new_callable=mocker.PropertyMock,
         return_value="sleep 1s",
     )
-    results_dir = tempfile.mkdtemp(dir=RESULTS_DIR)
-    # give the tmpdir the same permissions as the parent directory so that
-    # cluster jobs can write to it
-    os.chmod(results_dir, os.stat(RESULTS_DIR).st_mode)
     with pytest.raises(SystemExit) as exit:
         main(
             command="run",
             pipeline_specification=SPECIFICATIONS_DIR / "integration" / "pipeline.yaml",
             input_data=SPECIFICATIONS_DIR / "common/input_data.yaml",
             computing_environment=SPECIFICATIONS_DIR / "common/environment_local.yaml",
-            results_dir=results_dir,
+            results_dir=test_specific_results_dir,
         )
     assert exit.value.code == 1
     assert "MissingOutputException" in caplog.text

--- a/tests/specifications/integration/embarrassingly_parallel/pipeline_loop_step.yaml
+++ b/tests/specifications/integration/embarrassingly_parallel/pipeline_loop_step.yaml
@@ -1,0 +1,7 @@
+steps:
+  step_1:
+    iterate:
+      - implementation:
+          name: step_1_python_pandas
+      - implementation:
+          name: step_1_python_pandas


### PR DESCRIPTION
## Title: Add new test type: custom-schema integration test
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> test
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5978
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This adds a new type of test - a nearly e2e test (calls runner.main)
and passes in a custom schema. This should allow for nearly full coverage of
actually running custom schemas (instead of officially changing the development
schema to test the runnability of different compositions).

This does not add anything new featurewise - it's just testing the already-existing
(and actually supported in the official development schema) looping
of an embarrassingly parallel step.

NOTE: Wjhile at it, I cleaned up how we generate and delete (or often don't, oops)
tmpdirs for each test. Now there's a fixture that yields the dir to the test
and then removes it at the end. It doesn't work 100% perfectly but seems
to be pretty close.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

