### PR TITLE
Sbachmei/bugfix/fix embarrassingly parallel steps

### DIFF
--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -83,20 +83,8 @@ NODES = [
                 ),
             ],
             output_slots=[OutputSlot("step_3_main_output", aggregator=concatenate_datasets)],
-            input_slot_mappings=[
-                InputSlotMapping(
-                    parent_slot="step_3_main_input",
-                    child_node="step_3",
-                    child_slot="step_3_main_input",
-                ),
-            ],
-            output_slot_mappings=[
-                OutputSlotMapping(
-                    parent_slot="step_3_main_output",
-                    child_node="step_3",
-                    child_slot="step_3_main_output",
-                ),
-            ],
+            # splitter=(split_data_by_size, "step_3_main_input"),
+            # aggregator=(concatenate_datasets, "step_3_main_output"),
         ),
         self_edges=[
             EdgeParams(

--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -74,17 +74,8 @@ NODES = [
                     ),
                 ],
             ),
-            input_slots=[
-                InputSlot(
-                    name="step_3_main_input",
-                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-                    validator=validate_input_file_dummy,
-                    splitter=split_data_by_size,
-                ),
-            ],
-            output_slots=[OutputSlot("step_3_main_output", aggregator=concatenate_datasets)],
-            # splitter=(split_data_by_size, "step_3_main_input"),
-            # aggregator=(concatenate_datasets, "step_3_main_output"),
+            splitter={"step_3_main_input": split_data_by_size},
+            aggregator={"step_3_main_output": concatenate_datasets},
         ),
         self_edges=[
             EdgeParams(

--- a/src/easylink/pipeline_schema_constants/testing.py
+++ b/src/easylink/pipeline_schema_constants/testing.py
@@ -389,20 +389,6 @@ LOOPING_EP_STEP_NODES = [
                 ),
             ],
             output_slots=[OutputSlot("step_1_main_output", aggregator=concatenate_datasets)],
-            input_slot_mappings=[
-                InputSlotMapping(
-                    parent_slot="step_1_main_input",
-                    child_node="step_1",
-                    child_slot="step_1_main_input",
-                ),
-            ],
-            output_slot_mappings=[
-                OutputSlotMapping(
-                    parent_slot="step_1_main_output",
-                    child_node="step_1",
-                    child_slot="step_1_main_output",
-                ),
-            ],
         ),
         self_edges=[
             EdgeParams(

--- a/src/easylink/pipeline_schema_constants/testing.py
+++ b/src/easylink/pipeline_schema_constants/testing.py
@@ -380,15 +380,8 @@ LOOPING_EP_STEP_NODES = [
                     ),
                 ],
             ),
-            input_slots=[
-                InputSlot(
-                    name="step_1_main_input",
-                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-                    validator=validate_input_file_dummy,
-                    splitter=split_data_in_two,
-                ),
-            ],
-            output_slots=[OutputSlot("step_1_main_output", aggregator=concatenate_datasets)],
+            splitter={"step_1_main_input": split_data_in_two},
+            aggregator={"step_1_main_output": concatenate_datasets},
         ),
         self_edges=[
             EdgeParams(

--- a/tests/integration/test_compositions.py
+++ b/tests/integration/test_compositions.py
@@ -12,7 +12,7 @@ EP_SPECIFICATIONS_DIR = SPECIFICATIONS_DIR / "integration" / "embarrassingly_par
 
 
 @pytest.mark.slow
-def test_looping_embarrassingly_parallel_step(test_specific_results_dir: Path):
+def test_looping_embarrassingly_parallel_step(test_specific_results_dir: Path) -> None:
     pipeline_specification = EP_SPECIFICATIONS_DIR / "pipeline_loop_step.yaml"
     input_data = COMMON_SPECIFICATIONS_DIR / "input_data.yaml"
 
@@ -46,7 +46,7 @@ def _run_pipeline(
     pipeline_specification: Path,
     input_data: Path,
     computing_environment: Path | None = None,
-):
+) -> None:
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         main(
             command="run",

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1156,19 +1156,13 @@ def embarrassingly_parallel_step_params() -> dict[str, Any]:
         ),
         "input_slots": [
             InputSlot(
-                "ep_step_3_main_input",
+                "step_3_main_input",
                 "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
                 split_data_by_size,
             )
         ],
-        "output_slots": [OutputSlot("ep_step_3_main_output", concatenate_datasets)],
-        "input_slot_mappings": [
-            InputSlotMapping("ep_step_3_main_input", "step_3", "step_3_main_input")
-        ],
-        "output_slot_mappings": [
-            OutputSlotMapping("ep_step_3_main_output", "step_3", "step_3_main_output")
-        ],
+        "output_slots": [OutputSlot("step_3_main_output", concatenate_datasets)],
     }
 
 
@@ -1178,15 +1172,15 @@ def test_embarrassingly_parallel_step_slots(
     step = EmbarrassinglyParallelStep(**embarrassingly_parallel_step_params)
     assert step.name == "step_3"
     assert step.input_slots == {
-        "ep_step_3_main_input": InputSlot(
-            "ep_step_3_main_input",
+        "step_3_main_input": InputSlot(
+            "step_3_main_input",
             "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
             validate_input_file_dummy,
             split_data_by_size,
         ),
     }
     assert step.output_slots == {
-        "ep_step_3_main_output": OutputSlot("ep_step_3_main_output", concatenate_datasets),
+        "step_3_main_output": OutputSlot("step_3_main_output", concatenate_datasets),
     }
 
 
@@ -1317,8 +1311,6 @@ def test_embarrassingly_parallel_step__validation(
         ),
         "input_slots": input_slots,
         "output_slots": output_slots,
-        "input_slot_mappings": [],
-        "output_slot_mappings": [],
     }
     with pytest.raises(ValueError) as error:
         EmbarrassinglyParallelStep(**step_params)
@@ -1437,38 +1429,20 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
         ),
         "input_slots": [
             InputSlot(
-                "ep_steps_1_2_3_main_input",
+                "steps_1_2_3_main_input",
                 "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
                 split_data_by_size,
             ),
             InputSlot(
-                "ep_steps_1_2_3_secondary_input",
+                "steps_1_2_3_secondary_input",
                 "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
             ),
         ],
         "output_slots": [
-            OutputSlot("ep_steps_1_2_3_main_output", concatenate_datasets),
-            OutputSlot("ep_steps_1_2_3_secondary_output", concatenate_datasets),
-        ],
-        "input_slot_mappings": [
-            InputSlotMapping(
-                "ep_steps_1_2_3_main_input", "steps_1_2_3", "steps_1_2_3_main_input"
-            ),
-            InputSlotMapping(
-                "ep_steps_1_2_3_secondary_input", "steps_1_2_3", "steps_1_2_3_secondary_input"
-            ),
-        ],
-        "output_slot_mappings": [
-            OutputSlotMapping(
-                "ep_steps_1_2_3_main_output", "steps_1_2_3", "steps_1_2_3_main_output"
-            ),
-            OutputSlotMapping(
-                "ep_steps_1_2_3_secondary_output",
-                "steps_1_2_3",
-                "steps_1_2_3_secondary_output",
-            ),
+            OutputSlot("steps_1_2_3_main_output", concatenate_datasets),
+            OutputSlot("steps_1_2_3_secondary_output", concatenate_datasets),
         ],
     }
 
@@ -1588,26 +1562,19 @@ def embarrassingly_parallel_loop_step_params(
         "step": LoopStep(**loop_step_params),
         "input_slots": [
             InputSlot(
-                "ep_step_3_main_input",
+                "step_3_main_input",
                 "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
                 split_data_by_size,
             ),
             InputSlot(
-                "ep_step_3_secondary_input",
+                "step_3_secondary_input",
                 "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
             ),
         ],
         "output_slots": [
-            OutputSlot("ep_step_3_main_output", concatenate_datasets),
-        ],
-        "input_slot_mappings": [
-            InputSlotMapping("ep_step_3_main_input", "step_3", "step_3_main_input"),
-            InputSlotMapping("ep_step_3_secondary_input", "step_3", "step_3_secondary_input"),
-        ],
-        "output_slot_mappings": [
-            OutputSlotMapping("ep_step_3_main_output", "step_3", "step_3_main_output"),
+            OutputSlot("step_3_main_output", concatenate_datasets),
         ],
     }
 
@@ -1703,7 +1670,7 @@ def test_embarrassingly_parallel_loop_step_implementation_graph(
             "step_3a_main_input": {
                 "splitter": split_data_by_size,
                 "splitter_origin_node": "step_3",
-                "splitter_origin_slot": "ep_step_3_main_input",
+                "splitter_origin_slot": "step_3_main_input",
             },
             # nothing defined on secondary input slots or the output slot
         },
@@ -1713,7 +1680,7 @@ def test_embarrassingly_parallel_loop_step_implementation_graph(
             "step_3_main_output": {
                 "aggregator": concatenate_datasets,
                 "splitter_origin_node": "step_3",
-                "splitter_origin_slot": "ep_step_3_main_input",
+                "splitter_origin_slot": "step_3_main_input",
             },
             # nothing defined on the secondary input slot or the output slot
         },
@@ -1755,26 +1722,19 @@ def embarrassingly_parallel_parallel_step_params(
         "step": ParallelStep(**parallel_step_params),
         "input_slots": [
             InputSlot(
-                "ep_step_1_main_input",
+                "step_1_main_input",
                 "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
                 split_data_by_size,
             ),
             InputSlot(
-                "ep_step_1_secondary_input",
+                "step_1_secondary_input",
                 "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS",
                 validate_input_file_dummy,
             ),
         ],
         "output_slots": [
-            OutputSlot("ep_step_1_main_output", concatenate_datasets),
-        ],
-        "input_slot_mappings": [
-            InputSlotMapping("ep_step_1_main_input", "step_1", "step_1_main_input"),
-            InputSlotMapping("ep_step_1_secondary_input", "step_1", "step_1_secondary_input"),
-        ],
-        "output_slot_mappings": [
-            OutputSlotMapping("ep_step_1_main_output", "step_1", "step_1_main_output"),
+            OutputSlot("step_1_main_output", concatenate_datasets),
         ],
     }
 


### PR DESCRIPTION
## Fix EmbarrassinglyParallelSteps

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5988
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> There were a few issues in EmbarrassinglyParallelSteps:
- We were not setting the parent step
- we were using its name in places we should have been using the
child name
- We were assigning slot mappings when we really didn't need to be
- Taking the above a step further, we really don't need to assign
i/o slots on both the outer layer and in the sub-child.


### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tests pass and can run the two e2e pipelines.
