### PR TITLE
Don't install graphviz backend for doc-only installs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.13 - 4/21/25**
+
+ - remove graphviz from doc build install
+
 **0.1.12 - 4/1/25**
 
  - Propagate embarrassingly parallel splitters and aggregators to leaf steps

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ include $(MAKE_INCLUDES)/test.mk
 install:
 	# Don't install Graphviz for docs. This could break if we add doctests which require graphviz!
 	# Note that installing the python package graphviz doesn't actually require the graphviz system package.
-	$(if $(filter-out doc,${ENV_REQS:=dev}),conda install -y python-graphviz,)
+	$(if $(filter-out docs,${ENV_REQS}),conda install -y python-graphviz,)
 	$(MAKE) -f $(MAKE_INCLUDES)/base.mk install ENV_REQS=${ENV_REQS}

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,7 @@ include $(MAKE_INCLUDES)/base.mk
 include $(MAKE_INCLUDES)/test.mk
 
 install:
-	conda install -y python-graphviz
-	$(MAKE) -f $(MAKE_INCLUDES)/base.mk install
+	# Don't install Graphviz for docs. This could break if we add doctests which require graphviz!
+	# Note that installing the python package graphviz doesn't actually require the graphviz system package.
+	$(if $(filter-out doc,${ENV_REQS:=dev}),conda install -y python-graphviz,)
+	$(MAKE) -f $(MAKE_INCLUDES)/base.mk install ENV_REQS=${ENV_REQS}

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ PACKAGE_NAME = easylink
 include $(MAKE_INCLUDES)/base.mk
 include $(MAKE_INCLUDES)/test.mk
 
+install: ENV_REQS?=dev
 install:
-	# Don't install Graphviz for docs. This could break if we add doctests which require graphviz!
-	# Note that installing the python package graphviz doesn't actually require the graphviz system package.
+# Don't install Graphviz for docs. This could break if we add doctests which require graphviz!
+# Note that installing the python package graphviz doesn't actually require the graphviz system package.
 	$(if $(filter-out docs,${ENV_REQS}),conda install -y python-graphviz,)
 	$(MAKE) -f $(MAKE_INCLUDES)/base.mk install ENV_REQS=${ENV_REQS}


### PR DESCRIPTION
## Don't install graphviz backend for doc-only installs.
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
CI
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5995
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Only install graphviz backend if we aren't doing [a doc install.](https://github.com/ihmeuw/vivarium_build_utils/pull/36)
This is to accommodate doc-only tests, which have this download as a bottleneck.
It isn't perfect, as the pip install installs the python graphviz package, which would rely on the backend were it actually called.
Either way, if doctests were added that actually use graphviz somehow, we'd have to remove this and just eat the download time cost. Hopefully, we'll just move away from using it at all, and implement our own plotting scheme, which would also obviate this.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

locally tested that `make install` and `make install ENV_REQS=docs` works as expected.