### PR TITLE
Sbachmei/mic 5987/implement splitter steps and aggregator steps

### DIFF
--- a/src/easylink/graph_components.py
+++ b/src/easylink/graph_components.py
@@ -79,7 +79,7 @@ class InputSlot:
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class OutputSlot:
     """A single output slot from a specific node.
 

--- a/src/easylink/graph_components.py
+++ b/src/easylink/graph_components.py
@@ -54,13 +54,13 @@ class InputSlot:
     with a descriptive error message which will then be reported to the user.
     **Note that the function *must* be defined in the** :mod:`easylink.utilities.validation_utils` 
     **module!**"""
-    splitter: Callable[[list[str], str, Any], None] | None = field(
-        default=None, compare=False
-    )
-    """A function that splits the incoming data to this ``InputSlot`` into smaller
-    pieces. The primary purpose of this functionality is to run sections of the 
-    pipeline in an embarrassingly parallel manner. **Note that the function *must* 
-    be defined in the **:mod:`easylink.utilities.splitter_utils`** module!**"""
+    # splitter: Callable[[list[str], str, Any], None] | None = field(
+    #     default=None, compare=False
+    # )
+    # """A function that splits the incoming data to this ``InputSlot`` into smaller
+    # pieces. The primary purpose of this functionality is to run sections of the
+    # pipeline in an embarrassingly parallel manner. **Note that the function *must*
+    # be defined in the **:mod:`easylink.utilities.splitter_utils`** module!**"""
     # splitter_origin_node: str = None
     # """The name of the node where a splitter is originally defined."""
     # splitter_origin_slot: str = None
@@ -76,13 +76,13 @@ class InputSlot:
             return NotImplemented
         validator_name = self.validator.__name__ if self.validator else None
         other_validator_name = other.validator.__name__ if other.validator else None
-        splitter_name = self.splitter.__name__ if self.splitter else None
-        other_splitter_name = other.splitter.__name__ if other.splitter else None
+        # splitter_name = self.splitter.__name__ if self.splitter else None
+        # other_splitter_name = other.splitter.__name__ if other.splitter else None
         return (
             self.name == other.name
             and self.env_var == other.env_var
             and validator_name == other_validator_name
-            and splitter_name == other_splitter_name
+            # and splitter_name == other_splitter_name
             # and self.splitter_origin_node == other.splitter_origin_node
             # and self.splitter_origin_slot == other.splitter_origin_slot
         )
@@ -93,13 +93,13 @@ class InputSlot:
         The hash is based on the name of the ``InputSlot``, its ``env_var``, and
         the names of its ``validator`` and ``splitter``.
         """
-        splitter_name = self.splitter.__name__ if self.splitter else None
+        # splitter_name = self.splitter.__name__ if self.splitter else None
         return hash(
             (
                 self.name,
                 self.env_var,
                 self.validator.__name__,
-                splitter_name,
+                # splitter_name,
                 # self.splitter_origin_node,
                 # self.splitter_origin_slot,
             )
@@ -127,11 +127,11 @@ class OutputSlot:
 
     name: str
     """The name of the ``OutputSlot``."""
-    aggregator: Callable[[list[str], str], None] = field(default=None, compare=False)
-    """A function that aggregates all of the generated data to be passed out via this
-    ``OutputSlot``. The primary purpose of this functionality is to run sections
-    of the pipeline in an embarrassingly parallel manner. **Note that the function 
-    *must* be defined in the **:py:mod:`easylink.utilities.aggregator_utils`** module!**"""
+    # aggregator: Callable[[list[str], str], None] = field(default=None, compare=False)
+    # """A function that aggregates all of the generated data to be passed out via this
+    # ``OutputSlot``. The primary purpose of this functionality is to run sections
+    # of the pipeline in an embarrassingly parallel manner. **Note that the function
+    # *must* be defined in the **:py:mod:`easylink.utilities.aggregator_utils`** module!**"""
     # splitter_origin_node: str = None
     # """The name of the node where the aggregator's corresponding splitter is originally defined."""
     # splitter_origin_slot: str = None
@@ -145,11 +145,12 @@ class OutputSlot:
         """
         if not isinstance(other, OutputSlot):
             return NotImplemented
-        aggregator_name = self.aggregator.__name__ if self.aggregator else None
-        other_aggregator_name = other.aggregator.__name__ if other.aggregator else None
+        # aggregator_name = self.aggregator.__name__ if self.aggregator else None
+        # other_aggregator_name = other.aggregator.__name__ if other.aggregator else None
         return (
-            self.name == other.name
-            and aggregator_name == other_aggregator_name
+            self.name
+            == other.name
+            # and aggregator_name == other_aggregator_name
             # and self.splitter_origin_node == other.splitter_origin_node
             # and self.splitter_origin_slot == other.splitter_origin_slot
         )
@@ -159,11 +160,11 @@ class OutputSlot:
 
         The hash is based on the name of the ``OutputSlot`` and the name of its ``aggregator``.
         """
-        aggregator_name = self.aggregator.__name__ if self.aggregator else None
+        # aggregator_name = self.aggregator.__name__ if self.aggregator else None
         return hash(
             (
                 self.name,
-                aggregator_name,
+                # aggregator_name,
                 # self.splitter_origin_node,
                 # self.splitter_origin_slot,
             )

--- a/src/easylink/graph_components.py
+++ b/src/easylink/graph_components.py
@@ -54,54 +54,26 @@ class InputSlot:
     with a descriptive error message which will then be reported to the user.
     **Note that the function *must* be defined in the** :mod:`easylink.utilities.validation_utils` 
     **module!**"""
-    # splitter: Callable[[list[str], str, Any], None] | None = field(
-    #     default=None, compare=False
-    # )
-    # """A function that splits the incoming data to this ``InputSlot`` into smaller
-    # pieces. The primary purpose of this functionality is to run sections of the
-    # pipeline in an embarrassingly parallel manner. **Note that the function *must*
-    # be defined in the **:mod:`easylink.utilities.splitter_utils`** module!**"""
-    # splitter_origin_node: str = None
-    # """The name of the node where a splitter is originally defined."""
-    # splitter_origin_slot: str = None
-    # """The name of the ``InputSlot`` where a splitter is originally defined."""
 
     def __eq__(self, other: Any) -> bool | NotImplementedType:
-        """Checks if two ``InputSlots`` are equal.
-
-        Two ``InputSlots`` are considered equal if their names, ``env_vars``, and
-        names of their ``validators`` and ``splitters`` are all the same.
-        """
+        """Checks if two ``InputSlots`` are equal."""
         if not isinstance(other, InputSlot):
             return NotImplemented
         validator_name = self.validator.__name__ if self.validator else None
         other_validator_name = other.validator.__name__ if other.validator else None
-        # splitter_name = self.splitter.__name__ if self.splitter else None
-        # other_splitter_name = other.splitter.__name__ if other.splitter else None
         return (
             self.name == other.name
             and self.env_var == other.env_var
             and validator_name == other_validator_name
-            # and splitter_name == other_splitter_name
-            # and self.splitter_origin_node == other.splitter_origin_node
-            # and self.splitter_origin_slot == other.splitter_origin_slot
         )
 
     def __hash__(self) -> int:
-        """Hashes an ``InputSlot``.
-
-        The hash is based on the name of the ``InputSlot``, its ``env_var``, and
-        the names of its ``validator`` and ``splitter``.
-        """
-        # splitter_name = self.splitter.__name__ if self.splitter else None
+        """Hashes an ``InputSlot``."""
         return hash(
             (
                 self.name,
                 self.env_var,
                 self.validator.__name__,
-                # splitter_name,
-                # self.splitter_origin_node,
-                # self.splitter_origin_slot,
             )
         )
 
@@ -127,48 +99,16 @@ class OutputSlot:
 
     name: str
     """The name of the ``OutputSlot``."""
-    # aggregator: Callable[[list[str], str], None] = field(default=None, compare=False)
-    # """A function that aggregates all of the generated data to be passed out via this
-    # ``OutputSlot``. The primary purpose of this functionality is to run sections
-    # of the pipeline in an embarrassingly parallel manner. **Note that the function
-    # *must* be defined in the **:py:mod:`easylink.utilities.aggregator_utils`** module!**"""
-    # splitter_origin_node: str = None
-    # """The name of the node where the aggregator's corresponding splitter is originally defined."""
-    # splitter_origin_slot: str = None
-    # """The name of the ``InputSlot`` where the aggregator's corresponding splitter is originally defined."""
 
     def __eq__(self, other: Any) -> bool | NotImplementedType:
-        """Checks if two ``OutputSlots`` are equal.
-
-        Two ``OutputSlots`` are considered equal if their names and the names of their
-        ``aggregators`` are the same.
-        """
+        """Checks if two ``OutputSlots`` are equal."""
         if not isinstance(other, OutputSlot):
             return NotImplemented
-        # aggregator_name = self.aggregator.__name__ if self.aggregator else None
-        # other_aggregator_name = other.aggregator.__name__ if other.aggregator else None
-        return (
-            self.name
-            == other.name
-            # and aggregator_name == other_aggregator_name
-            # and self.splitter_origin_node == other.splitter_origin_node
-            # and self.splitter_origin_slot == other.splitter_origin_slot
-        )
+        return self.name == other.name
 
     def __hash__(self) -> int:
-        """Hashes an ``OutputSlot``.
-
-        The hash is based on the name of the ``OutputSlot`` and the name of its ``aggregator``.
-        """
-        # aggregator_name = self.aggregator.__name__ if self.aggregator else None
-        return hash(
-            (
-                self.name,
-                # aggregator_name,
-                # self.splitter_origin_node,
-                # self.splitter_origin_slot,
-            )
-        )
+        """Hashes an ``OutputSlot``."""
+        return hash(self.name)
 
 
 @dataclass(frozen=True)

--- a/src/easylink/graph_components.py
+++ b/src/easylink/graph_components.py
@@ -69,11 +69,12 @@ class InputSlot:
 
     def __hash__(self) -> int:
         """Hashes an ``InputSlot``."""
+        validator_name = self.validator.__name__ if self.validator else None
         return hash(
             (
                 self.name,
                 self.env_var,
-                self.validator.__name__,
+                validator_name,
             )
         )
 

--- a/src/easylink/graph_components.py
+++ b/src/easylink/graph_components.py
@@ -101,16 +101,6 @@ class OutputSlot:
     name: str
     """The name of the ``OutputSlot``."""
 
-    def __eq__(self, other: Any) -> bool | NotImplementedType:
-        """Checks if two ``OutputSlots`` are equal."""
-        if not isinstance(other, OutputSlot):
-            return NotImplemented
-        return self.name == other.name
-
-    def __hash__(self) -> int:
-        """Hashes an ``OutputSlot``."""
-        return hash(self.name)
-
 
 @dataclass(frozen=True)
 class EdgeParams:

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -48,8 +48,8 @@ class Implementation:
         self,
         schema_steps: list[str],
         implementation_config: LayeredConfigTree,
-        input_slots: Iterable["InputSlot"] = (),
-        output_slots: Iterable["OutputSlot"] = (),
+        input_slots: Iterable[InputSlot] = (),
+        output_slots: Iterable[OutputSlot] = (),
         is_embarrassingly_parallel: bool = False,
     ):
         self.name = implementation_config.name
@@ -263,8 +263,8 @@ class PartialImplementation:
         self,
         combined_name: str,
         schema_step: str,
-        input_slots: Iterable["InputSlot"] = (),
-        output_slots: Iterable["OutputSlot"] = (),
+        input_slots: Iterable[InputSlot] = (),
+        output_slots: Iterable[OutputSlot] = (),
     ):
         self.combined_name = combined_name
         """The name of the combined implementation of which this ``PartialImplementation``

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -11,7 +11,7 @@ information about what container to run for a given step and other related detai
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -208,8 +208,8 @@ class NullAggregatorImplementation(NullImplementation):
 
     Parameters
     ----------
-    slot_aggregator_mapping
-        A mapping of slot names to their respective aggregation functions.
+    aggregator_func_name
+        The name of the aggregation function to use.
     splitter_node_name
         The name of the :class:`~easylink.step.SplitterStep` and its corresponding
         :class:`NullSplitterImplementation` that did the splitting.
@@ -221,12 +221,12 @@ class NullAggregatorImplementation(NullImplementation):
         name: str,
         input_slots: Iterable[InputSlot],
         output_slots: Iterable[OutputSlot],
-        slot_aggregator_mapping: dict[str, Callable],
+        aggregator_func_name: str,
         splitter_node_name: str,
     ):
         super().__init__(name, input_slots, output_slots)
-        self.slot_aggregator_mapping = slot_aggregator_mapping
-        """A mapping of slot names to their respective aggregation functions."""
+        self.aggregator_func_name = aggregator_func_name
+        """The name of the aggregation function to use."""
         self.splitter_node_name = splitter_node_name
         """The name of the :class:`~easylink.step.SplitterStep` and its corresponding
         :class:`NullSplitterImplementation` that did the splitting."""

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -9,14 +9,19 @@ information about what container to run for a given step and other related detai
 
 """
 
-from collections.abc import Iterable
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from layered_config_tree import LayeredConfigTree
 
-from easylink.graph_components import InputSlot, OutputSlot
 from easylink.utilities import paths
 from easylink.utilities.data_utils import load_yaml
+
+if TYPE_CHECKING:
+    from easylink.graph_components import InputSlot, OutputSlot
 
 
 class Implementation:
@@ -156,8 +161,8 @@ class NullImplementation:
     def __init__(
         self,
         name: str,
-        input_slots: Iterable["InputSlot"] = (),
-        output_slots: Iterable["OutputSlot"] = (),
+        input_slots: Iterable[InputSlot] = (),
+        output_slots: Iterable[OutputSlot] = (),
     ):
         self.name = name
         """The name of this ``NullImplementation``."""
@@ -170,6 +175,35 @@ class NullImplementation:
         self.combined_name = None
         """The name of the combined implementation of which ``NullImplementation`` 
         is a constituent. This is definitionally None."""
+
+
+class NullSplitterImplementation(NullImplementation):
+    def __init__(
+        self,
+        name: str,
+        input_slots: Iterable[InputSlot],
+        output_slots: Iterable[OutputSlot],
+        splitter_func_name: str,
+    ):
+        super().__init__(name, input_slots, output_slots)
+        self.splitter_func_name = splitter_func_name
+        """The name of the splitter function to use."""
+
+
+class NullAggregatorImplementation(NullImplementation):
+    def __init__(
+        self,
+        name: str,
+        input_slots: Iterable[InputSlot],
+        output_slots: Iterable[OutputSlot],
+        slot_aggregator_mapping: dict[str, Callable],
+        splitter_step_name: str,
+    ):
+        super().__init__(name, input_slots, output_slots)
+        self.slot_aggregator_mapping = slot_aggregator_mapping
+        """A mapping of slot names to their respective aggregation functions."""
+        self.splitter_step_name = splitter_step_name
+        """The name of the step that did the splitting that this is now aggregating."""
 
 
 class PartialImplementation:

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -210,8 +210,9 @@ class NullAggregatorImplementation(NullImplementation):
     ----------
     slot_aggregator_mapping
         A mapping of slot names to their respective aggregation functions.
-    splitter_step_name
-        The name of the step that did the splitting.
+    splitter_node_name
+        The name of the :class:`~easylink.step.SplitterStep` and its corresponding
+        :class:`NullSplitterImplementation` that did the splitting.
 
     """
 
@@ -221,13 +222,14 @@ class NullAggregatorImplementation(NullImplementation):
         input_slots: Iterable[InputSlot],
         output_slots: Iterable[OutputSlot],
         slot_aggregator_mapping: dict[str, Callable],
-        splitter_step_name: str,
+        splitter_node_name: str,
     ):
         super().__init__(name, input_slots, output_slots)
         self.slot_aggregator_mapping = slot_aggregator_mapping
         """A mapping of slot names to their respective aggregation functions."""
-        self.splitter_step_name = splitter_step_name
-        """The name of the step that did the splitting."""
+        self.splitter_node_name = splitter_node_name
+        """The name of the :class:`~easylink.step.SplitterStep` and its corresponding
+        :class:`NullSplitterImplementation` that did the splitting."""
 
 
 class PartialImplementation:

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -142,9 +142,8 @@ class Implementation:
 class NullImplementation:
     """A partial :class:`Implementation` interface when no container is needed to run.
 
-    The primary use case for this class is when adding an
-    :class:`~easylink.step.IOStep` - which does not have a corresponding
-    ``Implementation`` - to an :class:`~easylink.graph_components.ImplementationGraph`
+    The primary use case for this class is to be able to add a :class:`~easylink.step.Step`
+    that does *not* have a corresponding ``Implementation`` to an :class:`~easylink.graph_components.ImplementationGraph`
     since adding any new node requires an object with :class:`~easylink.graph_components.InputSlot`
     and :class:`~easylink.graph_components.OutputSlot` names.
 
@@ -156,6 +155,7 @@ class NullImplementation:
         All required ``InputSlots``.
     output_slots
         All required ``OutputSlots``.
+
     """
 
     def __init__(
@@ -178,6 +178,17 @@ class NullImplementation:
 
 
 class NullSplitterImplementation(NullImplementation):
+    """A type of :class:`NullImplementation` specifically for :class:`SplitterSteps<easylink.step.SplitterStep>`.
+
+    See ``NullImplementation`` for inherited attributes.
+
+    Parameters
+    ----------
+    splitter_func_name
+        The name of the splitter function to use.
+
+    """
+
     def __init__(
         self,
         name: str,
@@ -191,6 +202,19 @@ class NullSplitterImplementation(NullImplementation):
 
 
 class NullAggregatorImplementation(NullImplementation):
+    """A type of :class:`NullImplementation` specifically for :class:`AggregatorSteps<easylink.step.AggregatorStep>`.
+
+    See ``NullImplementation`` for inherited attributes.
+
+    Parameters
+    ----------
+    slot_aggregator_mapping
+        A mapping of slot names to their respective aggregation functions.
+    splitter_step_name
+        The name of the step that did the splitting.
+
+    """
+
     def __init__(
         self,
         name: str,
@@ -203,7 +227,7 @@ class NullAggregatorImplementation(NullImplementation):
         self.slot_aggregator_mapping = slot_aggregator_mapping
         """A mapping of slot names to their respective aggregation functions."""
         self.splitter_step_name = splitter_step_name
-        """The name of the step that did the splitting that this is now aggregating."""
+        """The name of the step that did the splitting."""
 
 
 class PartialImplementation:

--- a/src/easylink/pipeline.py
+++ b/src/easylink/pipeline.py
@@ -291,9 +291,9 @@ use rule start_spark_worker from spark_cluster with:
             The name of the ``Implementation`` to write the rule(s) for.
         """
 
-        is_embarrassingly_parallel = self.pipeline_graph.get_embarrassingly_parallel_details(
+        is_embarrassingly_parallel = self.pipeline_graph.get_whether_embarrassingly_parallel(
             node_name
-        )["is_embarrassingly_parallel"]
+        )
         input_slots, _output_slots = self.pipeline_graph.get_io_slot_attributes(node_name)
         validation_files, validation_rules = self._get_validations(
             node_name, input_slots, is_embarrassingly_parallel

--- a/src/easylink/pipeline.py
+++ b/src/easylink/pipeline.py
@@ -102,7 +102,7 @@ class Pipeline:
             self._write_aggregation_rule(
                 node_name,
                 checkpoint_filepaths[
-                    self.pipeline_graph.nodes[node_name]["implementation"].splitter_step_name
+                    self.pipeline_graph.nodes[node_name]["implementation"].splitter_node_name
                 ],
             )
         return self.snakefile_path
@@ -377,14 +377,13 @@ use rule start_spark_worker from spark_cluster with:
                 "There should always only be a single output file from an AggregationRule."
             )
         implementation = self.pipeline_graph.nodes[node_name]["implementation"]
-        splitter_step_name = implementation.splitter_step_name
         for output_slot_name, output_slot_attrs in output_slots.items():
             # We need to aggregate *each* output slot
             if len(output_slot_attrs["filepaths"]) > 1:
                 raise NotImplementedError(
                     "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
                 )
-            checkpoint_rule_name = f"checkpoints.{splitter_step_name}"
+            checkpoint_rule_name = f"checkpoints.{implementation.splitter_node_name}"
             AggregationRule(
                 name=f"{node_name}_{output_slot_name}",
                 input_files=input_files[0],

--- a/src/easylink/pipeline.py
+++ b/src/easylink/pipeline.py
@@ -303,74 +303,6 @@ use rule start_spark_worker from spark_cluster with:
 
         _input_files, output_files = self.pipeline_graph.get_io_filepaths(node_name)
 
-        # if embarrassingly_parallel_details["is_embarrassingly_parallel"]:
-        #     breakpoint()
-        #     # Update the outputs to be the processed chunks
-        #     if len(output_files) > 1:
-        #         raise NotImplementedError(
-        #             "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
-        #         )
-        #     output_files = [
-        #         str(
-        #             Path(output_files[0]).parent
-        #             / "processed/{chunk}"
-        #             / Path(output_files[0]).name
-        #         )
-        #     ]
-
-        # Create a splitter origin mapper to reduce bottlenecks later.
-        # Loop through all implementations and their input slots and generate
-        # a mapping of any splitter origin nodes and slots to the names of the
-        # implementation and input slot that they are defined at.
-        # i.e. {(splitter_origin_node, splitter_origin_slot): (implementation_name, implementation_input_slot)}
-        # splitter_origin_mapper = {}
-        # # checkpoint_output_dir = None
-        # for implementation, implementation_node in zip(
-        #     self.pipeline_graph.implementations, self.pipeline_graph.implementation_nodes
-        # ):
-        #     for input_slot_name, input_slot in implementation.input_slots.items():
-        #         key = (input_slot.splitter_origin_node, input_slot.splitter_origin_slot)
-        #         if key == (None, None):  # no splitter origin to map
-        #             continue
-        #         if key not in splitter_origin_mapper:
-        #             splitter_origin_mapper[key] = (implementation_node, input_slot_name)
-        #         else:
-        #             raise ValueError(
-        #                 f"Duplicate splitter found for {key}: "
-        #                 f"{splitter_origin_mapper[key]} and {implementation_node}"
-        #             )
-
-        # Extract where the checkpoint output dir is located
-        # FIXME: this won't work for ep sections b/c the output directory
-        # for a non-splitting node is definitely not where the checkpoint
-        # directory is located
-        # checkpoint_output_dir = output_files[0].split("/processed/")[0] + "/input_chunks"
-        # if embarrassingly_parallel_details["is_splitter"]:
-        #     input_slots_to_split = self._get_input_slots_to_split(input_slots)
-        #     if len(input_slots_to_split) > 1:
-        #         raise NotImplementedError(
-        #             "FIXME [MIC-5883] Multiple input slots to split not yet supported"
-        #         )
-        #     input_slot_to_split = input_slots_to_split[0]
-        #     breakpoint()
-        #     self._write_checkpoint_rule(
-        #         node_name,
-        #         input_slots,
-        #         input_slot_to_split,
-        #         validation_files,
-        #         checkpoint_output_dir,
-        #     )
-
-        #     # Update the input files to be the unprocessed chunks in '/input_chunks/{chunk}'
-        #     input_slots[input_slot_to_split]["filepaths"] = [
-        #         checkpoint_output_dir + "/{chunk}/result.parquet"
-        #     ]
-
-        # if embarrassingly_parallel_details["is_aggregator"]:
-        #     self._write_aggregation_rule(
-        #         node_name, output_slots, splitter_origin_mapper, checkpoint_output_dir
-        #     )
-
         implementation = self.pipeline_graph.nodes[node_name]["implementation"]
         diagnostics_dir = Path("diagnostics") / node_name
         diagnostics_dir.mkdir(parents=True, exist_ok=True)
@@ -394,28 +326,6 @@ use rule start_spark_worker from spark_cluster with:
             requires_spark=implementation.requires_spark,
             is_embarrassingly_parallel=is_embarrassingly_parallel,
         ).write_to_snakefile(self.snakefile_path)
-
-    # def _write_checkpoint_rule(
-    #     self,
-    #     node_name,
-    #     input_slots,
-    #     input_slot_to_split,
-    #     validation_files,
-    #     checkpoint_output_dir,
-    # ):
-    #     """Writes the snakemake checkpoint rule.
-
-    #     This build the ``CheckpointRule`` which splits the data into (unprocessed)
-    #     chunks and saves them to this step's '/input_chunks/' subdirectory.
-    #     """
-    #     CheckpointRule(
-    #         name=node_name,
-    #         input_files=input_slots[input_slot_to_split]["filepaths"],
-    #         input_slot_to_split=input_slot_to_split,
-    #         splitter_name=input_slots[input_slot_to_split]["splitter"].__name__,
-    #         validations=validation_files,
-    #         output_dir=checkpoint_output_dir,
-    #     ).write_to_snakefile(self.snakefile_path)
 
     def _write_checkpoint_rule(self, node_name: str, checkpoint_filepath: str):
         """TBD"""
@@ -442,40 +352,6 @@ use rule start_spark_worker from spark_cluster with:
             output_dir=output_dir,
             checkpoint_filepath=checkpoint_filepath,
         ).write_to_snakefile(self.snakefile_path)
-
-    # def _write_aggregation_rule(
-    #     self, node_name, output_slots, splitter_origin_mapper, checkpoint_output_dir
-    # ):
-    #     """Writes the snakemake aggregation rule."""
-    #     for output_slot_name, output_slot_attrs in output_slots.items():
-    #         # We need to aggregate *each* output slot
-    #         if len(output_slot_attrs["filepaths"]) > 1:
-    #             raise NotImplementedError(
-    #                 "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
-    #             )
-    #         aggregated_output_file = output_slot_attrs["filepaths"][0]
-    #         # Use the mapping to get the checkpoint_filepath
-    #         split_node, splitting_slot = splitter_origin_mapper[
-    #             (
-    #                 output_slot_attrs["splitter_origin_node"],
-    #                 output_slot_attrs["splitter_origin_slot"],
-    #             )
-    #         ]
-    #         checkpoint_rule_name = f"checkpoints.split_{split_node}_{splitting_slot}"
-    #         processed_chunks_to_aggregate = str(
-    #             Path(aggregated_output_file).parent
-    #             / "processed/{chunk}"
-    #             / Path(aggregated_output_file).name
-    #         )
-    #         AggregationRule(
-    #             name=node_name,
-    #             input_files=processed_chunks_to_aggregate,
-    #             output_slot_name=output_slot_name,
-    #             aggregated_output_file=aggregated_output_file,
-    #             aggregator_name=output_slot_attrs["aggregator"].__name__,
-    #             checkpoint_filepath=str(Path(checkpoint_output_dir) / "checkpoint.txt"),
-    #             checkpoint_rule_name=checkpoint_rule_name,
-    #         ).write_to_snakefile(self.snakefile_path)
 
     def _write_aggregation_rule(self, node_name: str, checkpoint_filepath: str):
         """Writes the snakemake aggregation rule."""

--- a/src/easylink/pipeline.py
+++ b/src/easylink/pipeline.py
@@ -95,6 +95,16 @@ class Pipeline:
         self._write_spark_module()
         for node_name in self.pipeline_graph.implementation_nodes:
             self._write_implementation_rules(node_name)
+        checkpoint_filepaths = self._get_checkpoint_filepaths()
+        for node_name in self.pipeline_graph.splitter_nodes:
+            self._write_checkpoint_rule(node_name, checkpoint_filepaths[node_name])
+        for node_name in self.pipeline_graph.aggregator_nodes:
+            self._write_aggregation_rule(
+                node_name,
+                checkpoint_filepaths[
+                    self.pipeline_graph.nodes[node_name]["implementation"].splitter_step_name
+                ],
+            )
         return self.snakefile_path
 
     ##################
@@ -140,6 +150,26 @@ class Pipeline:
             for slot_name, slot_attrs in input_slot_dict.items()
             if slot_attrs.get("splitter", None)
         ]
+
+    def _get_checkpoint_filepaths(self) -> dict[str, str]:
+        checkpoint_filepaths = {}
+        for node_name in self.pipeline_graph.splitter_nodes:
+            _input_files, output_files = self.pipeline_graph.get_io_filepaths(node_name)
+            if len(output_files) > 1:
+                raise ValueError(
+                    "The list of output files from a CheckpointRule should always be "
+                    "length 1; wildcards handle the fact that there are actually "
+                    "multiple files."
+                )
+            # The snakemake checkpoint rule requires the output parent directory
+            # to the chunked sub-directories (which are created by the splitter).
+            # e.g. if the chunks are eventually going to be written to
+            # 'intermediate/split_step_1_python_pandas/{chunk}/result.parquet',
+            # we need the output directory 'intermediate/split_step_1_python_pandas'
+            checkpoint_filepaths[node_name] = str(
+                Path(output_files[0]).parent.parent / "checkpoint.txt"
+            )
+        return checkpoint_filepaths
 
     #################################
     # Snakefile Rule Writer Methods #
@@ -261,81 +291,85 @@ use rule start_spark_worker from spark_cluster with:
             The name of the ``Implementation`` to write the rule(s) for.
         """
 
-        input_slots, output_slots = self.pipeline_graph.get_io_slot_attributes(node_name)
-        validation_files, validation_rules = self._get_validations(node_name, input_slots)
+        is_embarrassingly_parallel = self.pipeline_graph.get_embarrassingly_parallel_details(
+            node_name
+        )["is_embarrassingly_parallel"]
+        input_slots, _output_slots = self.pipeline_graph.get_io_slot_attributes(node_name)
+        validation_files, validation_rules = self._get_validations(
+            node_name, input_slots, is_embarrassingly_parallel
+        )
         for validation_rule in validation_rules:
             validation_rule.write_to_snakefile(self.snakefile_path)
 
         _input_files, output_files = self.pipeline_graph.get_io_filepaths(node_name)
-        embarrassingly_parallel_details = (
-            self.pipeline_graph.get_embarrassingly_parallel_details(node_name)
-        )
 
-        if embarrassingly_parallel_details["is_embarrassingly_parallel"]:
-            # Update the outputs to be the processed chunks
-            if len(output_files) > 1:
-                raise NotImplementedError(
-                    "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
-                )
-            output_files = [
-                str(
-                    Path(output_files[0]).parent
-                    / "processed/{chunk}"
-                    / Path(output_files[0]).name
-                )
-            ]
+        # if embarrassingly_parallel_details["is_embarrassingly_parallel"]:
+        #     breakpoint()
+        #     # Update the outputs to be the processed chunks
+        #     if len(output_files) > 1:
+        #         raise NotImplementedError(
+        #             "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
+        #         )
+        #     output_files = [
+        #         str(
+        #             Path(output_files[0]).parent
+        #             / "processed/{chunk}"
+        #             / Path(output_files[0]).name
+        #         )
+        #     ]
 
-            # Create a splitter origin mapper to reduce bottlenecks later.
-            # Loop through all implementations and their input slots and generate
-            # a mapping of any splitter origin nodes and slots to the names of the
-            # implementation and input slot that they are defined at.
-            # i.e. {(splitter_origin_node, splitter_origin_slot): (implementation_name, implementation_input_slot)}
-            splitter_origin_mapper = {}
-            checkpoint_output_dir = None
-            for implementation, implementation_node in zip(
-                self.pipeline_graph.implementations, self.pipeline_graph.implementation_nodes
-            ):
-                for input_slot_name, input_slot in implementation.input_slots.items():
-                    key = (input_slot.splitter_origin_node, input_slot.splitter_origin_slot)
-                    if key == (None, None):  # no splitter origin to map
-                        continue
-                    if key not in splitter_origin_mapper:
-                        splitter_origin_mapper[key] = (implementation_node, input_slot_name)
-                    else:
-                        raise ValueError(
-                            f"Duplicate splitter found for {key}: "
-                            f"{splitter_origin_mapper[key]} and {implementation_node}"
-                        )
+        # Create a splitter origin mapper to reduce bottlenecks later.
+        # Loop through all implementations and their input slots and generate
+        # a mapping of any splitter origin nodes and slots to the names of the
+        # implementation and input slot that they are defined at.
+        # i.e. {(splitter_origin_node, splitter_origin_slot): (implementation_name, implementation_input_slot)}
+        # splitter_origin_mapper = {}
+        # # checkpoint_output_dir = None
+        # for implementation, implementation_node in zip(
+        #     self.pipeline_graph.implementations, self.pipeline_graph.implementation_nodes
+        # ):
+        #     for input_slot_name, input_slot in implementation.input_slots.items():
+        #         key = (input_slot.splitter_origin_node, input_slot.splitter_origin_slot)
+        #         if key == (None, None):  # no splitter origin to map
+        #             continue
+        #         if key not in splitter_origin_mapper:
+        #             splitter_origin_mapper[key] = (implementation_node, input_slot_name)
+        #         else:
+        #             raise ValueError(
+        #                 f"Duplicate splitter found for {key}: "
+        #                 f"{splitter_origin_mapper[key]} and {implementation_node}"
+        #             )
 
-            # Extract where the checkpoint output dir is located
-            # FIXME: this won't work for ep sections b/c the output directory
-            # for a non-splitting node is definitely not where the checkpoint
-            # directory is located
-            checkpoint_output_dir = output_files[0].split("/processed/")[0] + "/input_chunks"
-            if embarrassingly_parallel_details["is_splitter"]:
-                input_slots_to_split = self._get_input_slots_to_split(input_slots)
-                if len(input_slots_to_split) > 1:
-                    raise NotImplementedError(
-                        "FIXME [MIC-5883] Multiple input slots to split not yet supported"
-                    )
-                input_slot_to_split = input_slots_to_split[0]
-                self._write_checkpoint_rule(
-                    node_name,
-                    input_slots,
-                    input_slot_to_split,
-                    validation_files,
-                    checkpoint_output_dir,
-                )
+        # Extract where the checkpoint output dir is located
+        # FIXME: this won't work for ep sections b/c the output directory
+        # for a non-splitting node is definitely not where the checkpoint
+        # directory is located
+        # checkpoint_output_dir = output_files[0].split("/processed/")[0] + "/input_chunks"
+        # if embarrassingly_parallel_details["is_splitter"]:
+        #     input_slots_to_split = self._get_input_slots_to_split(input_slots)
+        #     if len(input_slots_to_split) > 1:
+        #         raise NotImplementedError(
+        #             "FIXME [MIC-5883] Multiple input slots to split not yet supported"
+        #         )
+        #     input_slot_to_split = input_slots_to_split[0]
+        #     breakpoint()
+        #     self._write_checkpoint_rule(
+        #         node_name,
+        #         input_slots,
+        #         input_slot_to_split,
+        #         validation_files,
+        #         checkpoint_output_dir,
+        #     )
 
-                # Update the input files to be the unprocessed chunks in '/input_chunks/{chunk}'
-                input_slots[input_slot_to_split]["filepaths"] = [
-                    checkpoint_output_dir + "/{chunk}/result.parquet"
-                ]
+        #     # Update the input files to be the unprocessed chunks in '/input_chunks/{chunk}'
+        #     input_slots[input_slot_to_split]["filepaths"] = [
+        #         checkpoint_output_dir + "/{chunk}/result.parquet"
+        #     ]
 
-            if embarrassingly_parallel_details["is_aggregator"]:
-                self._write_aggregation_rule(
-                    node_name, output_slots, splitter_origin_mapper, checkpoint_output_dir
-                )
+        # if embarrassingly_parallel_details["is_aggregator"]:
+        #     self._write_aggregation_rule(
+        #         node_name, output_slots, splitter_origin_mapper, checkpoint_output_dir
+        #     )
 
         implementation = self.pipeline_graph.nodes[node_name]["implementation"]
         diagnostics_dir = Path("diagnostics") / node_name
@@ -358,70 +392,130 @@ use rule start_spark_worker from spark_cluster with:
             image_path=implementation.singularity_image_path,
             script_cmd=implementation.script_cmd,
             requires_spark=implementation.requires_spark,
-            is_embarrassingly_parallel=embarrassingly_parallel_details[
-                "is_embarrassingly_parallel"
-            ],
+            is_embarrassingly_parallel=is_embarrassingly_parallel,
         ).write_to_snakefile(self.snakefile_path)
 
-    def _write_checkpoint_rule(
-        self,
-        node_name,
-        input_slots,
-        input_slot_to_split,
-        validation_files,
-        checkpoint_output_dir,
-    ):
-        """Writes the snakemake checkpoint rule.
+    # def _write_checkpoint_rule(
+    #     self,
+    #     node_name,
+    #     input_slots,
+    #     input_slot_to_split,
+    #     validation_files,
+    #     checkpoint_output_dir,
+    # ):
+    #     """Writes the snakemake checkpoint rule.
 
-        This build the ``CheckpointRule`` which splits the data into (unprocessed)
-        chunks and saves them to this step's '/input_chunks/' subdirectory.
-        """
+    #     This build the ``CheckpointRule`` which splits the data into (unprocessed)
+    #     chunks and saves them to this step's '/input_chunks/' subdirectory.
+    #     """
+    #     CheckpointRule(
+    #         name=node_name,
+    #         input_files=input_slots[input_slot_to_split]["filepaths"],
+    #         input_slot_to_split=input_slot_to_split,
+    #         splitter_name=input_slots[input_slot_to_split]["splitter"].__name__,
+    #         validations=validation_files,
+    #         output_dir=checkpoint_output_dir,
+    #     ).write_to_snakefile(self.snakefile_path)
+
+    def _write_checkpoint_rule(self, node_name: str, checkpoint_filepath: str):
+        """TBD"""
+        splitter_func_name = self.pipeline_graph.nodes[node_name][
+            "implementation"
+        ].splitter_func_name
+        input_files, output_files = self.pipeline_graph.get_io_filepaths(node_name)
+        if len(output_files) > 1:
+            raise ValueError(
+                "The list of output files from a CheckpointRule should always be "
+                "length 1; wildcards handle the fact that there are actually "
+                "multiple files."
+            )
+        # The snakemake checkpoint rule requires the output parent directory
+        # to the chunked sub-directories (which are created by the splitter).
+        # e.g. if the chunks are eventually going to be written to
+        # 'intermediate/split_step_1_python_pandas/{chunk}/result.parquet',
+        # we need the output directory 'intermediate/split_step_1_python_pandas'
+        output_dir = str(Path(output_files[0]).parent.parent)
         CheckpointRule(
             name=node_name,
-            input_files=input_slots[input_slot_to_split]["filepaths"],
-            input_slot_to_split=input_slot_to_split,
-            splitter_name=input_slots[input_slot_to_split]["splitter"].__name__,
-            validations=validation_files,
-            output_dir=checkpoint_output_dir,
+            input_files=input_files,
+            splitter_func_name=splitter_func_name,
+            output_dir=output_dir,
+            checkpoint_filepath=checkpoint_filepath,
         ).write_to_snakefile(self.snakefile_path)
 
-    def _write_aggregation_rule(
-        self, node_name, output_slots, splitter_origin_mapper, checkpoint_output_dir
-    ):
+    # def _write_aggregation_rule(
+    #     self, node_name, output_slots, splitter_origin_mapper, checkpoint_output_dir
+    # ):
+    #     """Writes the snakemake aggregation rule."""
+    #     for output_slot_name, output_slot_attrs in output_slots.items():
+    #         # We need to aggregate *each* output slot
+    #         if len(output_slot_attrs["filepaths"]) > 1:
+    #             raise NotImplementedError(
+    #                 "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
+    #             )
+    #         aggregated_output_file = output_slot_attrs["filepaths"][0]
+    #         # Use the mapping to get the checkpoint_filepath
+    #         split_node, splitting_slot = splitter_origin_mapper[
+    #             (
+    #                 output_slot_attrs["splitter_origin_node"],
+    #                 output_slot_attrs["splitter_origin_slot"],
+    #             )
+    #         ]
+    #         checkpoint_rule_name = f"checkpoints.split_{split_node}_{splitting_slot}"
+    #         processed_chunks_to_aggregate = str(
+    #             Path(aggregated_output_file).parent
+    #             / "processed/{chunk}"
+    #             / Path(aggregated_output_file).name
+    #         )
+    #         AggregationRule(
+    #             name=node_name,
+    #             input_files=processed_chunks_to_aggregate,
+    #             output_slot_name=output_slot_name,
+    #             aggregated_output_file=aggregated_output_file,
+    #             aggregator_name=output_slot_attrs["aggregator"].__name__,
+    #             checkpoint_filepath=str(Path(checkpoint_output_dir) / "checkpoint.txt"),
+    #             checkpoint_rule_name=checkpoint_rule_name,
+    #         ).write_to_snakefile(self.snakefile_path)
+
+    def _write_aggregation_rule(self, node_name: str, checkpoint_filepath: str):
         """Writes the snakemake aggregation rule."""
+        _input_slots, output_slots = self.pipeline_graph.get_io_slot_attributes(node_name)
+        input_files, output_files = self.pipeline_graph.get_io_filepaths(node_name)
+        if len(input_files) > 1:
+            raise ValueError(
+                "The list of input files to an AggregationRule should always be "
+                "length 1; wildcards handle the fact that there are actually "
+                "multiple files."
+            )
+        if len(output_files) > 1:
+            raise ValueError(
+                "There should always only be a single output file from an AggregationRule."
+            )
+        implementation = self.pipeline_graph.nodes[node_name]["implementation"]
+        splitter_step_name = implementation.splitter_step_name
         for output_slot_name, output_slot_attrs in output_slots.items():
             # We need to aggregate *each* output slot
             if len(output_slot_attrs["filepaths"]) > 1:
                 raise NotImplementedError(
                     "FIXME [MIC-5883] Multiple output slots/files of EmbarrassinglyParallelSteps not yet supported"
                 )
-            aggregated_output_file = output_slot_attrs["filepaths"][0]
-            # Use the mapping to get the checkpoint_filepath
-            split_node, splitting_slot = splitter_origin_mapper[
-                (
-                    output_slot_attrs["splitter_origin_node"],
-                    output_slot_attrs["splitter_origin_slot"],
-                )
-            ]
-            checkpoint_rule_name = f"checkpoints.split_{split_node}_{splitting_slot}"
-            processed_chunks_to_aggregate = str(
-                Path(aggregated_output_file).parent
-                / "processed/{chunk}"
-                / Path(aggregated_output_file).name
-            )
+            checkpoint_rule_name = f"checkpoints.{splitter_step_name}"
             AggregationRule(
-                name=node_name,
-                input_files=processed_chunks_to_aggregate,
-                output_slot_name=output_slot_name,
-                aggregated_output_file=aggregated_output_file,
-                aggregator_name=output_slot_attrs["aggregator"].__name__,
-                checkpoint_filepath=str(Path(checkpoint_output_dir) / "checkpoint.txt"),
+                name=f"{node_name}_{output_slot_name}",
+                input_files=input_files[0],
+                aggregated_output_file=output_files[0],
+                aggregator_func_name=implementation.slot_aggregator_mapping[
+                    output_slot_name
+                ].__name__,
+                checkpoint_filepath=checkpoint_filepath,
                 checkpoint_rule_name=checkpoint_rule_name,
             ).write_to_snakefile(self.snakefile_path)
 
     @staticmethod
     def _get_validations(
-        node_name, input_slots
+        node_name: str,
+        input_slots: dict[str, dict[str, str | list[str]]],
+        is_embarrassingly_parallel: bool,
     ) -> tuple[list[str], list[InputValidationRule]]:
         """Gets the validation rule and its output filepath for each slot for a given node.
 
@@ -440,7 +534,11 @@ use rule start_spark_worker from spark_cluster with:
         validation_rules = []
 
         for input_slot_name, input_slot_attrs in input_slots.items():
-            validation_file = f"input_validations/{node_name}/{input_slot_name}_validator"
+            # embarrassingly parallel implementations rely on snakemake wildcards
+            # TODO: [MIC-5787] - need to support multiple wildcards at once
+            validation_file = f"input_validations/{node_name}/{input_slot_name}_validator" + (
+                "-{chunk}" if is_embarrassingly_parallel else ""
+            )
             validation_files.append(validation_file)
             validation_rules.append(
                 InputValidationRule(

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -77,62 +77,26 @@ class PipelineGraph(ImplementationGraph):
         to be run in an embarrassingly parallel way."""
         return any(
             [
-                self.get_embarrassingly_parallel_details(node)["is_embarrassingly_parallel"]
+                self.get_whether_embarrassingly_parallel(node)
                 for node in self.implementation_nodes
             ]
         )
 
-    def get_embarrassingly_parallel_details(self, node: str) -> dict[str, bool]:
+    def get_whether_embarrassingly_parallel(self, node: str) -> dict[str, bool]:
         """Determines whether a node is to be run in an embarrassingly parallel way.
 
         Parameters
         ----------
         node
-            The node name to determine details about whether it is to be run in an
+            The node name to determine whether or not it is to be run in an
             embarrassingly parallel way.
 
         Returns
         -------
-            The details describing whether or not the node is to be run in an embarrassingly
-            parallel way, has a splitter defined, or has an aggregator defined, respectively.
-
-        Raises
-        ------
-        ValueError
-            If the node is marked as being a splitter or aggregator but is not
-            embarrassingly parallel.
-
-        Notes
-        -----
-        A node should never have a splitter or aggregator defined if it is *not*
-        embarrassingly parallel. However, nodes can be embarrassingly parallel
-        but not require splitting or aggregating (e.g. if you are running a series
-        of three substeps 'step_1a', 'step_1b', and 'step_1c' via a
-        :class:`~easylink.step.HierarchicalStep` in an embarrassingly parallel
-        manner, all three are embarrassingly parallel, but only 'step_1a' is to
-        split the input data and only 'step_1c' is the aggregate the results).
+            A boolean indicating whether the node is to be run in an embarrassingly
+            parallel way.
         """
-        implementation = self.nodes[node]["implementation"]
-        details = {
-            "is_embarrassingly_parallel": implementation.is_embarrassingly_parallel,
-            "is_splitter": any(slot.splitter for slot in implementation.input_slots.values()),
-            "is_aggregator": any(
-                slot.aggregator for slot in implementation.output_slots.values()
-            ),
-        }
-
-        unexpected = []
-        if details["is_splitter"] and not details["is_embarrassingly_parallel"]:
-            unexpected.append("splitter")
-        if details["is_aggregator"] and not details["is_embarrassingly_parallel"]:
-            unexpected.append("aggregator")
-        if unexpected:
-            raise ValueError(
-                f"Node '{node}' is marked as being a {' and '.join(unexpected)} "
-                "but not embarrassingly parallel."
-            )
-
-        return details
+        return self.nodes[node]["implementation"].is_embarrassingly_parallel
 
     def get_io_filepaths(self, node: str) -> tuple[list[str], list[str]]:
         """Gets all of a node's input and output filepaths from its edges.
@@ -568,21 +532,21 @@ class PipelineGraph(ImplementationGraph):
                 slot_name,
                 env_var,
                 validator,
-                splitter,
+                # splitter,
                 # splitter_origin_node,
                 # splitter_origin_slot,
             ) = (
                 input_slot.name,
                 input_slot.env_var,
                 input_slot.validator,
-                input_slot.splitter,
+                # input_slot.splitter,
                 # input_slot.splitter_origin_node,
                 # input_slot.splitter_origin_slot,
             )
             attrs = {
                 "env_var": env_var,
                 "validator": validator,
-                "splitter": splitter,
+                # "splitter": splitter,
                 # "splitter_origin_node": splitter_origin_node,
                 # "splitter_origin_slot": splitter_origin_slot,
             }
@@ -599,7 +563,7 @@ class PipelineGraph(ImplementationGraph):
                     "env_var": env_var,
                     "validator": validator,
                     "filepaths": filepaths,
-                    "splitter": splitter,
+                    # "splitter": splitter,
                     # "splitter_origin_node": splitter_origin_node,
                     # "splitter_origin_slot": splitter_origin_slot,
                 }
@@ -626,26 +590,26 @@ class PipelineGraph(ImplementationGraph):
         for output_slot, filepaths in zip(output_slots, filepaths_by_slot):
             (
                 slot_name,
-                aggregator,
+                # aggregator,
                 # splitter_origin_node,
                 # splitter_origin_slot,
             ) = (
                 output_slot.name,
-                output_slot.aggregator,
+                # output_slot.aggregator,
                 # output_slot.splitter_origin_node,
                 # output_slot.splitter_origin_slot,
             )
-            attrs = {
-                "aggregator": aggregator,
-                # "splitter_origin_node": splitter_origin_node,
-                # "splitter_origin_slot": splitter_origin_slot,
-            }
+            # attrs = {
+            #     # "aggregator": aggregator,
+            #     # "splitter_origin_node": splitter_origin_node,
+            #     # "splitter_origin_slot": splitter_origin_slot,
+            # }
             if slot_name in condensed_slot_dict:
-                for key, value in attrs.items():
-                    if value != condensed_slot_dict[slot_name][key]:
-                        raise ValueError(
-                            f"Duplicate output slots named '{slot_name}' have different {key} values."
-                        )
+                # for key, value in attrs.items():
+                #     if value != condensed_slot_dict[slot_name][key]:
+                #         raise ValueError(
+                #             f"Duplicate output slots named '{slot_name}' have different {key} values."
+                #         )
                 # Add any new/unique filepaths to the existing slot
                 condensed_slot_dict[slot_name]["filepaths"].extend(
                     item
@@ -655,7 +619,7 @@ class PipelineGraph(ImplementationGraph):
             else:
                 condensed_slot_dict[slot_name] = {
                     "filepaths": filepaths,
-                    "aggregator": aggregator,
+                    # "aggregator": aggregator,
                     # "splitter_origin_node": splitter_origin_node,
                     # "splitter_origin_slot": splitter_origin_slot,
                 }

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -528,27 +528,14 @@ class PipelineGraph(ImplementationGraph):
         """
         condensed_slot_dict = {}
         for input_slot, filepaths in zip(input_slots, filepaths_by_slot):
-            (
-                slot_name,
-                env_var,
-                validator,
-                # splitter,
-                # splitter_origin_node,
-                # splitter_origin_slot,
-            ) = (
+            (slot_name, env_var, validator,) = (
                 input_slot.name,
                 input_slot.env_var,
                 input_slot.validator,
-                # input_slot.splitter,
-                # input_slot.splitter_origin_node,
-                # input_slot.splitter_origin_slot,
             )
             attrs = {
                 "env_var": env_var,
                 "validator": validator,
-                # "splitter": splitter,
-                # "splitter_origin_node": splitter_origin_node,
-                # "splitter_origin_slot": splitter_origin_slot,
             }
             if slot_name in condensed_slot_dict:
                 for key, value in attrs.items():
@@ -563,9 +550,6 @@ class PipelineGraph(ImplementationGraph):
                     "env_var": env_var,
                     "validator": validator,
                     "filepaths": filepaths,
-                    # "splitter": splitter,
-                    # "splitter_origin_node": splitter_origin_node,
-                    # "splitter_origin_slot": splitter_origin_slot,
                 }
         return condensed_slot_dict
 
@@ -588,28 +572,8 @@ class PipelineGraph(ImplementationGraph):
         """
         condensed_slot_dict = {}
         for output_slot, filepaths in zip(output_slots, filepaths_by_slot):
-            (
-                slot_name,
-                # aggregator,
-                # splitter_origin_node,
-                # splitter_origin_slot,
-            ) = (
-                output_slot.name,
-                # output_slot.aggregator,
-                # output_slot.splitter_origin_node,
-                # output_slot.splitter_origin_slot,
-            )
-            # attrs = {
-            #     # "aggregator": aggregator,
-            #     # "splitter_origin_node": splitter_origin_node,
-            #     # "splitter_origin_slot": splitter_origin_slot,
-            # }
+            slot_name = output_slot.name
             if slot_name in condensed_slot_dict:
-                # for key, value in attrs.items():
-                #     if value != condensed_slot_dict[slot_name][key]:
-                #         raise ValueError(
-                #             f"Duplicate output slots named '{slot_name}' have different {key} values."
-                #         )
                 # Add any new/unique filepaths to the existing slot
                 condensed_slot_dict[slot_name]["filepaths"].extend(
                     item
@@ -619,8 +583,5 @@ class PipelineGraph(ImplementationGraph):
             else:
                 condensed_slot_dict[slot_name] = {
                     "filepaths": filepaths,
-                    # "aggregator": aggregator,
-                    # "splitter_origin_node": splitter_origin_node,
-                    # "splitter_origin_slot": splitter_origin_slot,
                 }
         return condensed_slot_dict

--- a/src/easylink/pipeline_graph.py
+++ b/src/easylink/pipeline_graph.py
@@ -492,6 +492,8 @@ class PipelineGraph(ImplementationGraph):
             implementation = self.nodes[node]["implementation"]
             for src, sink, edge_attrs in self.out_edges(node, data=True):
                 for edge_idx in self[node][sink]:
+                    # splitter nodes rely on snakemake wildcards
+                    # TODO: [MIC-5787] - need to support multiple wildcards at once
                     self[src][sink][edge_idx]["filepaths"] = (
                         str(Path("intermediate") / node / "{chunk}" / "result.parquet"),
                     )
@@ -528,7 +530,7 @@ class PipelineGraph(ImplementationGraph):
         """
         condensed_slot_dict = {}
         for input_slot, filepaths in zip(input_slots, filepaths_by_slot):
-            (slot_name, env_var, validator,) = (
+            slot_name, env_var, validator = (
                 input_slot.name,
                 input_slot.env_var,
                 input_slot.validator,

--- a/src/easylink/pipeline_schema_constants/development.py
+++ b/src/easylink/pipeline_schema_constants/development.py
@@ -74,8 +74,8 @@ NODES = [
                     ),
                 ],
             ),
-            splitter={"step_3_main_input": split_data_by_size},
-            aggregator={"step_3_main_output": concatenate_datasets},
+            slot_splitter_mapping={"step_3_main_input": split_data_by_size},
+            slot_aggregator_mapping={"step_3_main_output": concatenate_datasets},
         ),
         self_edges=[
             EdgeParams(

--- a/src/easylink/pipeline_schema_constants/testing.py
+++ b/src/easylink/pipeline_schema_constants/testing.py
@@ -380,8 +380,8 @@ LOOPING_EP_STEP_NODES = [
                     ),
                 ],
             ),
-            splitter={"step_1_main_input": split_data_in_two},
-            aggregator={"step_1_main_output": concatenate_datasets},
+            slot_splitter_mapping={"step_1_main_input": split_data_in_two},
+            slot_aggregator_mapping={"step_1_main_output": concatenate_datasets},
         ),
         self_edges=[
             EdgeParams(

--- a/src/easylink/rule.py
+++ b/src/easylink/rule.py
@@ -145,10 +145,11 @@ rule:
             env_var = attrs["env_var"].lower()
             input_str += f"""
         {env_var}={attrs["filepaths"]},"""
-        if not self.is_embarrassingly_parallel:
-            # validations were already handled in the checkpoint rule - no need
-            # to validate the individual chunks
-            input_str += f"""
+        # if not self.is_embarrassingly_parallel:
+        #     # validations were already handled in the checkpoint rule - no need
+        #     # to validate the individual chunks
+        #     input_str += f"""
+        input_str += f"""
         validations={self.validations},"""
         if self.requires_spark:
             input_str += f"""
@@ -223,7 +224,7 @@ class InputValidationRule(Rule):
     """List of filepaths to validate."""
     output: str
     """Filepath of validation output. It must be used as an input for next rule."""
-    validator: Callable
+    validator: Callable | None
     """Callable that takes a filepath as input. Raises an error if invalid."""
 
     def build_rule(self) -> str:
@@ -244,6 +245,75 @@ rule:
     run:
         for f in input:
             validation_utils.{self.validator.__name__}(f)"""
+
+
+# @dataclass
+# class CheckpointRule(Rule):
+#     """A :class:`Rule` that defines a checkpoint.
+
+#     When running an :class:`~easylink.implementation.Implementation` in an embarrassingly
+#     parallel way, we do not know until runtime how many parallel jobs there will
+#     be (e.g. we don't know beforehand how many chunks a large incoming dataset will
+#     be split into since the incoming dataset isn't created until runtime). The
+#     snakemake mechanism to handle this dynamic nature is a
+#     `checkpoint <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution/>`_
+#     rule along with a directory as output.
+
+#     Notes
+#     -----
+#     There is a known `Snakemake bug <https://github.com/snakemake/snakemake/issues/3036>`_
+#     which prevents the use of multiple checkpoints in a single Snakefile. We
+#     work around this by generating an empty checkpoint.txt file as part of this
+#     rule. If this file does not yet exist when trying to run the :class:`AggregationRule`,
+#     it means that the checkpoint has not yet been executed for the
+#     particular wildcard value(s). In this case, we manually raise a Snakemake
+#     ``IncompleteCheckpointException`` which Snakemake automatically handles
+#     and leads to a re-evaluation after the checkpoint has successfully passed.
+
+#     TODO [MIC-5658]: Thoroughly test this workaround when implementing cacheing.
+#     """
+
+#     name: str
+#     """Name of the rule."""
+#     input_files: list[str]
+#     """The input filepaths."""
+#     input_slot_to_split: str
+#     """The input slot being split."""
+#     splitter_name: str
+#     """The splitter function's name."""
+#     validations: list[str]
+#     """Validation files from previous rule."""
+#     output_dir: str
+#     """Output directory path. It must be used as an input for next rule."""
+
+#     def build_rule(self) -> str:
+#         """Builds the Snakemake rule for this checkpoint.
+
+#         Checkpoint rules are a special type of rule in Snakemake that allow for dynamic
+#         generation of output files. This rule is responsible for splitting the input
+#         files into chunks. Note that the output of this rule is a Snakemake ``directory``
+#         object as opposed to a specific file like typical rules have.
+#         """
+#         checkpoint = f"""
+# checkpoint:
+#     name: "split_{self.name}_{self.input_slot_to_split}"
+#     input:
+#         files={self.input_files},
+#         validations={self.validations},
+#     output:
+#         output_dir=directory("{self.output_dir}"),
+#         checkpoint_file=touch("{self.output_dir}/checkpoint.txt"),
+#     params:
+#         input_files=lambda wildcards, input: ",".join(input.files),
+#     localrule: True
+#     message: "Splitting {self.name} {self.input_slot_to_split} into chunks"
+#     run:
+#         splitter_utils.{self.splitter_name}(
+#             input_files=list(input.files),
+#             output_dir=output.output_dir,
+#             desired_chunk_size_mb=0.1,
+#         )"""
+#         return checkpoint
 
 
 @dataclass
@@ -276,14 +346,12 @@ class CheckpointRule(Rule):
     """Name of the rule."""
     input_files: list[str]
     """The input filepaths."""
-    input_slot_to_split: str
-    """The input slot being split."""
-    splitter_name: str
+    splitter_func_name: str
     """The splitter function's name."""
-    validations: list[str]
-    """Validation files from previous rule."""
     output_dir: str
     """Output directory path. It must be used as an input for next rule."""
+    checkpoint_filepath: str
+    """Path to the checkpoint file. This is only needed for the bugfix workaround."""
 
     def build_rule(self) -> str:
         """Builds the Snakemake rule for this checkpoint.
@@ -295,19 +363,18 @@ class CheckpointRule(Rule):
         """
         checkpoint = f"""
 checkpoint:
-    name: "split_{self.name}_{self.input_slot_to_split}"
+    name: "{self.name}"
     input: 
         files={self.input_files},
-        validations={self.validations},
     output: 
         output_dir=directory("{self.output_dir}"),
-        checkpoint_file=touch("{self.output_dir}/checkpoint.txt"),
+        checkpoint_file=touch("{self.checkpoint_filepath}"),
     params:
         input_files=lambda wildcards, input: ",".join(input.files),
     localrule: True
-    message: "Splitting {self.name} {self.input_slot_to_split} into chunks"
+    message: "Splitting {self.name} into chunks"
     run:
-        splitter_utils.{self.splitter_name}(
+        splitter_utils.{self.splitter_func_name}(
             input_files=list(input.files),
             output_dir=output.output_dir,
             desired_chunk_size_mb=0.1,
@@ -328,11 +395,9 @@ class AggregationRule(Rule):
     """Name of the rule."""
     input_files: str
     """The input processed chunk files to aggregate."""
-    output_slot_name: str
-    """Name of the :class:`~easylink.graph_components.OutputSlot`."""
     aggregated_output_file: str
     """The final aggregated results file."""
-    aggregator_name: str
+    aggregator_func_name: str
     """The name of the aggregation function to run."""
     checkpoint_filepath: str
     """Path to the checkpoint file. This is only needed for the bugfix workaround."""
@@ -369,7 +434,7 @@ class AggregationRule(Rule):
     def _define_input_function(self):
         """Builds the `input function <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#input-functions>`_."""
         func = f"""
-def get_aggregation_inputs_{self.name}_{self.output_slot_name}(wildcards):
+def get_aggregation_inputs_{self.name}(wildcards):
     checkpoint_file = "{self.checkpoint_filepath}"
     if not os.path.exists(checkpoint_file):
         output, _ = {self.checkpoint_rule_name}.rule.expand_output(wildcards)
@@ -386,13 +451,13 @@ def get_aggregation_inputs_{self.name}_{self.output_slot_name}(wildcards):
         """Builds the rule that runs the aggregation."""
         rule = f"""
 rule:
-    name: "aggregate_{self.name}_{self.output_slot_name}"
-    input: get_aggregation_inputs_{self.name}_{self.output_slot_name}
+    name: "{self.name}"
+    input: get_aggregation_inputs_{self.name}
     output: {[self.aggregated_output_file]}
     localrule: True
-    message: "Aggregating {self.name} {self.output_slot_name}"
+    message: "Aggregating {self.name}"
     run:
-        aggregator_utils.{self.aggregator_name}(
+        aggregator_utils.{self.aggregator_func_name}(
             input_files=list(input),
             output_filepath="{self.aggregated_output_file}",
         )"""

--- a/src/easylink/rule.py
+++ b/src/easylink/rule.py
@@ -145,10 +145,6 @@ rule:
             env_var = attrs["env_var"].lower()
             input_str += f"""
         {env_var}={attrs["filepaths"]},"""
-        # if not self.is_embarrassingly_parallel:
-        #     # validations were already handled in the checkpoint rule - no need
-        #     # to validate the individual chunks
-        #     input_str += f"""
         input_str += f"""
         validations={self.validations},"""
         if self.requires_spark:
@@ -245,75 +241,6 @@ rule:
     run:
         for f in input:
             validation_utils.{self.validator.__name__}(f)"""
-
-
-# @dataclass
-# class CheckpointRule(Rule):
-#     """A :class:`Rule` that defines a checkpoint.
-
-#     When running an :class:`~easylink.implementation.Implementation` in an embarrassingly
-#     parallel way, we do not know until runtime how many parallel jobs there will
-#     be (e.g. we don't know beforehand how many chunks a large incoming dataset will
-#     be split into since the incoming dataset isn't created until runtime). The
-#     snakemake mechanism to handle this dynamic nature is a
-#     `checkpoint <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution/>`_
-#     rule along with a directory as output.
-
-#     Notes
-#     -----
-#     There is a known `Snakemake bug <https://github.com/snakemake/snakemake/issues/3036>`_
-#     which prevents the use of multiple checkpoints in a single Snakefile. We
-#     work around this by generating an empty checkpoint.txt file as part of this
-#     rule. If this file does not yet exist when trying to run the :class:`AggregationRule`,
-#     it means that the checkpoint has not yet been executed for the
-#     particular wildcard value(s). In this case, we manually raise a Snakemake
-#     ``IncompleteCheckpointException`` which Snakemake automatically handles
-#     and leads to a re-evaluation after the checkpoint has successfully passed.
-
-#     TODO [MIC-5658]: Thoroughly test this workaround when implementing cacheing.
-#     """
-
-#     name: str
-#     """Name of the rule."""
-#     input_files: list[str]
-#     """The input filepaths."""
-#     input_slot_to_split: str
-#     """The input slot being split."""
-#     splitter_name: str
-#     """The splitter function's name."""
-#     validations: list[str]
-#     """Validation files from previous rule."""
-#     output_dir: str
-#     """Output directory path. It must be used as an input for next rule."""
-
-#     def build_rule(self) -> str:
-#         """Builds the Snakemake rule for this checkpoint.
-
-#         Checkpoint rules are a special type of rule in Snakemake that allow for dynamic
-#         generation of output files. This rule is responsible for splitting the input
-#         files into chunks. Note that the output of this rule is a Snakemake ``directory``
-#         object as opposed to a specific file like typical rules have.
-#         """
-#         checkpoint = f"""
-# checkpoint:
-#     name: "split_{self.name}_{self.input_slot_to_split}"
-#     input:
-#         files={self.input_files},
-#         validations={self.validations},
-#     output:
-#         output_dir=directory("{self.output_dir}"),
-#         checkpoint_file=touch("{self.output_dir}/checkpoint.txt"),
-#     params:
-#         input_files=lambda wildcards, input: ",".join(input.files),
-#     localrule: True
-#     message: "Splitting {self.name} {self.input_slot_to_split} into chunks"
-#     run:
-#         splitter_utils.{self.splitter_name}(
-#             input_files=list(input.files),
-#             output_dir=output.output_dir,
-#             desired_chunk_size_mb=0.1,
-#         )"""
-#         return checkpoint
 
 
 @dataclass

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1287,9 +1287,9 @@ class EmbarrassinglyParallelStep(Step):
         input_data_config
             The input data configuration for the entire pipeline.
         """
-        splitter_step_name = f"{self.name}_{self.split_slot_name}_split"
+        splitter_node_name = f"{self.name}_{self.split_slot_name}_split"
         splitter_step = SplitterStep(
-            splitter_step_name,
+            splitter_node_name,
             split_slot=self.input_slots[self.split_slot_name],
             splitter_func_name=self.slot_splitter_mapping[self.split_slot_name].__name__,
         )
@@ -1298,7 +1298,7 @@ class EmbarrassinglyParallelStep(Step):
             aggregator_step_name,
             output_slots=self.output_slots.values(),
             slot_aggregator_mapping=self.slot_aggregator_mapping,
-            splitter_step_name=splitter_step_name,
+            splitter_node_name=splitter_node_name,
         )
         self._update_step_graph(splitter_step, aggregator_step)
         self._update_slot_mappings(splitter_step, aggregator_step)
@@ -1448,7 +1448,7 @@ class AggregatorStep(StandaloneStep):
         name: str,
         output_slots: Iterable[OutputSlot],
         slot_aggregator_mapping: dict[str, Callable],
-        splitter_step_name: str,
+        splitter_node_name: str,
     ) -> None:
         """A :class:`StandaloneStep` that aggregates :class:`OutputSlots<easylink.graph_components.Outputslot>` after parallel processing.
 
@@ -1462,9 +1462,10 @@ class AggregatorStep(StandaloneStep):
         slot_aggregator_mapping
             A mapping of all ``OutputSlot`` names to be aggregated and the actual
             aggregator function to be used.
-        splitter_step_name
-            The name of the ``SplitterStep`` that this ``AggregatorStep`` is associated with.
-
+        splitter_node_name
+            The name of the ``SplitterStep`` and its corresponding
+            :class:`~easylink.implementation.NullSplitterImplementation` that this ``AggregatorStep``
+            is associated with.
         """
         super().__init__(
             name,
@@ -1480,8 +1481,10 @@ class AggregatorStep(StandaloneStep):
         self.slot_aggregator_mapping = slot_aggregator_mapping
         """A mapping of all ``OutputSlot`` names to be aggregated and the actual 
         aggregator function to be used."""
-        self.splitter_step_name = splitter_step_name
-        """The name of the ``SplitterStep`` that this ``AggregatorStep`` is associated with."""
+        self.splitter_node_name = splitter_node_name
+        """The name of the ``SplitterStep`` and its corresponding
+        :class:`~easylink.implementation.NullSplitterImplementation` that this ``AggregatorStep``
+        is associated with."""
 
     def add_nodes_to_implementation_graph(
         self, implementation_graph: ImplementationGraph
@@ -1494,7 +1497,7 @@ class AggregatorStep(StandaloneStep):
                 self.input_slots.values(),
                 self.output_slots.values(),
                 self.slot_aggregator_mapping,
-                self.splitter_step_name,
+                self.splitter_node_name,
             ),
         )
 

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -1226,9 +1226,9 @@ class EmbarrassinglyParallelStep(Step):
         ``EmbarrassinglyParallelSteps`` are not configured by the user to be run
         in parallel. Since it happens on the back end, we need to do somewhat unique
         validations during construction. Specifically,
-        - one and only one :class:`~easylink.graph_components.InputSlot` *must* 
+        - one and only one :class:`~easylink.graph_components.InputSlot` *must*
         be mapped to a splitter method.
-        - all :class:`OutputSlots<easylink.graph_components.OutputSlot>` *must* 
+        - all :class:`OutputSlots<easylink.graph_components.OutputSlot>` *must*
         be mapped to aggregator methods.
         """
         errors = []

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -364,6 +364,21 @@ class StandaloneStep(Step, ABC):
         """
         return self.name
 
+    @abstractmethod
+    def add_nodes_to_implementation_graph(
+        self, implementation_graph: ImplementationGraph
+    ) -> None:
+        """Adds this ``StandaloneStep's`` ``Implementation`` as a node to the :class:`~easylink.graph_components.ImplementationGraph`.
+
+        Notes
+        -----
+        Unlike other types of ``Steps``, ``StandaloneSteps`` are not actually implemented
+        via an :class:`~easylink.implementation.Implementation`. As such, we
+        leverage the :class:`~easylink.implementation.NullImplementation` class
+        to generate the graph node.
+        """
+        pass
+
     def validate_step(
         self,
         step_config: LayeredConfigTree,
@@ -405,21 +420,6 @@ class StandaloneStep(Step, ABC):
         self._configuration_state = LeafConfigurationState(
             self, step_config, combined_implementations, input_data_config
         )
-
-    @abstractmethod
-    def add_nodes_to_implementation_graph(
-        self, implementation_graph: ImplementationGraph
-    ) -> None:
-        """Adds this ``StandaloneStep's`` ``Implementation`` as a node to the :class:`~easylink.graph_components.ImplementationGraph`.
-
-        Notes
-        -----
-        Unlike other types of ``Steps``, ``StandaloneSteps`` are not actually implemented
-        via an :class:`~easylink.implementation.Implementation`. As such, we
-        leverage the :class:`~easylink.implementation.NullImplementation` class
-        to generate the graph node.
-        """
-        pass
 
     def add_edges_to_implementation_graph(self, implementation_graph):
         """Adds the edges of this ``Step's`` ``Implementation`` to the ``ImplementationGraph``.
@@ -1226,10 +1226,10 @@ class EmbarrassinglyParallelStep(Step):
         ``EmbarrassinglyParallelSteps`` are not configured by the user to be run
         in parallel. Since it happens on the back end, we need to do somewhat unique
         validations during construction. Specifically,
-        - one and only one :class:`~easylink.graph_components.InputSlot` *must* include
-        a :attr:`~easylink.graph_components.InputSlot.splitter` method.
-        - all :class:`OutputSlots<easylink.graph_components.OutputSlot>` *must* include
-        an :attr:`~easylink.graph_components.OutputSlot.aggregator` method.
+        - one and only one :class:`~easylink.graph_components.InputSlot` *must* 
+        be mapped to a splitter method.
+        - all :class:`OutputSlots<easylink.graph_components.OutputSlot>` *must* 
+        be mapped to aggregator methods.
         """
         errors = []
 

--- a/src/easylink/step.py
+++ b/src/easylink/step.py
@@ -422,7 +422,7 @@ class StandaloneStep(Step, ABC):
         )
 
     def add_edges_to_implementation_graph(self, implementation_graph):
-        """Adds the edges of this ``Step's`` ``Implementation`` to the ``ImplementationGraph``.
+        """Overwrites the super ``Step``'s method to do nothing.
 
         ``StandaloneSteps`` do not have edges within them in the ``ImplementationGraph``,
         since they are represented by a single ``NullImplementation`` node, and so we

--- a/tests/e2e/test_step_types.py
+++ b/tests/e2e/test_step_types.py
@@ -29,8 +29,8 @@ from tests.conftest import SPECIFICATIONS_DIR
                 "step_1_parallel_split_2_step_1_python_pandas",
                 "step_1_parallel_split_3_step_1_python_pandas",
                 "step_2_python_pandas",
-                "step_3_loop_1_step_3_step_3_python_pandas",
-                "step_3_loop_2_step_3_step_3_python_pandas",
+                "step_3_loop_1_step_3_python_pandas",
+                "step_3_loop_2_step_3_python_pandas",
                 "step_4a_python_pandas",
                 "step_4b_python_pandas",
             ],
@@ -76,8 +76,8 @@ def test_step_types(
         # step_3 is embarrassingly parallel so the final results land in _aggregate/
         aggregate_mapping = {
             "step_3_python_pandas": "step_3_aggregate",
-            "step_3_loop_1_step_3_step_3_python_pandas": "step_3_loop_1_aggregate",
-            "step_3_loop_2_step_3_step_3_python_pandas": "step_3_loop_2_aggregate",
+            "step_3_loop_1_step_3_python_pandas": "step_3_loop_1_aggregate",
+            "step_3_loop_2_step_3_python_pandas": "step_3_loop_2_aggregate",
         }
         subdir = aggregate_mapping.get(implementation, implementation)
         assert (

--- a/tests/e2e/test_step_types.py
+++ b/tests/e2e/test_step_types.py
@@ -29,8 +29,8 @@ from tests.conftest import SPECIFICATIONS_DIR
                 "step_1_parallel_split_2_step_1_python_pandas",
                 "step_1_parallel_split_3_step_1_python_pandas",
                 "step_2_python_pandas",
-                "step_3_loop_1_step_3_python_pandas",
-                "step_3_loop_2_step_3_python_pandas",
+                "step_3_loop_1_step_3_step_3_python_pandas",
+                "step_3_loop_2_step_3_step_3_python_pandas",
                 "step_4a_python_pandas",
                 "step_4b_python_pandas",
             ],
@@ -49,7 +49,7 @@ def test_step_types(
     input_data = "common/input_data.yaml"
     computing_environment = "common/environment_local.yaml"
     with capsys.disabled():  # disabled so we can monitor job submissions
-        print("\n\n*** RUNNING TEST ***\n" f"[{pipeline_specification}]\n")
+        print("\n\n*** STARTING RUN ***\n" f"[{pipeline_specification}]\n")
 
         cmd = (
             "easylink run "
@@ -66,14 +66,20 @@ def test_step_types(
             stderr=sys.stderr,
             check=True,
         )
-        final_output = test_specific_results_dir / "result.parquet"
-        assert final_output.exists()
+        print("\n\n*** END OF RUN ***\n" f"[{pipeline_specification}]\n")
 
-        # Check that we get directories for particular implementations
-        diagnostics_dir = test_specific_results_dir / "diagnostics"
-        for implementation in implementations:
-            assert (diagnostics_dir / implementation).exists()
-            assert (
-                test_specific_results_dir / "intermediate" / implementation / "result.parquet"
-            ).exists()
-        print("\n\n*** END OF TEST ***\n" f"[{pipeline_specification}]\n")
+    assert (test_specific_results_dir / "result.parquet").exists()
+
+    # Check that we get directories for particular implementations
+    for implementation in implementations:
+        assert (test_specific_results_dir / "diagnostics" / implementation).exists()
+        # step_3 is embarrassingly parallel so the final results land in _aggregate/
+        aggregate_mapping = {
+            "step_3_python_pandas": "step_3_aggregate",
+            "step_3_loop_1_step_3_step_3_python_pandas": "step_3_loop_1_aggregate",
+            "step_3_loop_2_step_3_step_3_python_pandas": "step_3_loop_2_aggregate",
+        }
+        subdir = aggregate_mapping.get(implementation, implementation)
+        assert (
+            test_specific_results_dir / "intermediate" / subdir / "result.parquet"
+        ).exists()

--- a/tests/integration/test_compositions.py
+++ b/tests/integration/test_compositions.py
@@ -23,16 +23,34 @@ def test_looping_embarrassingly_parallel_step(test_specific_results_dir: Path) -
     _run_pipeline(schema, test_specific_results_dir, pipeline_specification, input_data)
 
     for loop in [1, 2]:
-        implementation = f"step_1_loop_{loop}_step_1_python_pandas"
-        implementation_subdir = test_specific_results_dir / "intermediate" / implementation
+        intermediate_results_dir = test_specific_results_dir / "intermediate"
+        step_name = f"step_1_loop_{loop}"
         # ensure that the input was split into two
         assert (
-            len(list((implementation_subdir / "input_chunks").rglob("result.parquet"))) == 2
+            len(
+                list(
+                    (intermediate_results_dir / f"{step_name}_step_1_main_input_split").rglob(
+                        "result.parquet"
+                    )
+                )
+            )
+            == 2
         )
         # ensure that each chunk was processed individually
-        assert len(list((implementation_subdir / "processed").rglob("result.parquet"))) == 2
+        assert (
+            len(
+                list(
+                    (
+                        intermediate_results_dir / f"{step_name}_step_1_step_1_python_pandas"
+                    ).rglob("result.parquet")
+                )
+            )
+            == 2
+        )
         # check for aggregated file
-        assert (implementation_subdir / "result.parquet").exists()
+        assert (
+            intermediate_results_dir / f"{step_name}_aggregate" / "result.parquet"
+        ).exists()
 
 
 ####################

--- a/tests/integration/test_compositions.py
+++ b/tests/integration/test_compositions.py
@@ -40,9 +40,9 @@ def test_looping_embarrassingly_parallel_step(test_specific_results_dir: Path) -
         assert (
             len(
                 list(
-                    (
-                        intermediate_results_dir / f"{step_name}_step_1_step_1_python_pandas"
-                    ).rglob("result.parquet")
+                    (intermediate_results_dir / f"{step_name}_step_1_python_pandas").rglob(
+                        "result.parquet"
+                    )
                 )
             )
             == 2

--- a/tests/unit/rule_strings/aggregation_rule.txt
+++ b/tests/unit/rule_strings/aggregation_rule.txt
@@ -1,23 +1,23 @@
 
-def get_aggregation_inputs_foo_rule_main_output(wildcards):
+def get_aggregation_inputs_this_is_an_aggregation_rule(wildcards):
     checkpoint_file = "this/is/the/checkpoint.txt"
     if not os.path.exists(checkpoint_file):
-        output, _ = checkpoints.split_some_split_node_some_split_slot.rule.expand_output(wildcards)
-        raise IncompleteCheckpointException(checkpoints.split_some_split_node_some_split_slot.rule, checkpoint_target(output[0]))
-    checkpoint_output = glob.glob(f"{checkpoints.split_some_split_node_some_split_slot.get(**wildcards).output.output_dir}/*/")
+        output, _ = checkpoints.this_is_a_checkpoint_rule.rule.expand_output(wildcards)
+        raise IncompleteCheckpointException(checkpoints.this_is_a_checkpoint_rule.rule, checkpoint_target(output[0]))
+    checkpoint_output = glob.glob(f"{checkpoints.this_is_a_checkpoint_rule.get(**wildcards).output.output_dir}/*/")
     chunks = [Path(filepath).parts[-1] for filepath in checkpoint_output]
     return expand(
-        "these/are/processed/{chunk}",
+        "these/are/processed/{chunk}/result.parquet",
         chunk=chunks
     )
 rule:
-    name: "aggregate_foo_rule_main_output"
-    input: get_aggregation_inputs_foo_rule_main_output
-    output: ['some/path/to/results/result.parquet']
+    name: "this_is_an_aggregation_rule"
+    input: get_aggregation_inputs_this_is_an_aggregation_rule
+    output: ['some/path/to/aggregated/results/result.parquet']
     localrule: True
-    message: "Aggregating foo_rule main_output"
+    message: "Aggregating this_is_an_aggregation_rule"
     run:
-        aggregator_utils._dummy_aggregator(
+        aggregator_utils.my_aggregator(
             input_files=list(input),
-            output_filepath="some/path/to/results/result.parquet",
+            output_filepath="some/path/to/aggregated/results/result.parquet",
         )

--- a/tests/unit/rule_strings/checkpoint_rule.txt
+++ b/tests/unit/rule_strings/checkpoint_rule.txt
@@ -1,18 +1,17 @@
 
 checkpoint:
-    name: "split_foo_rule_main"
+    name: "this_is_a_checkpoint_rule"
     input: 
         files=['some/input/file1', 'some/input/file2'],
-        validations=['baz'],
     output: 
-        output_dir=directory("some/path/to/quux"),
-        checkpoint_file=touch("some/path/to/quux/checkpoint.txt"),
+        output_dir=directory("this/is/the/output/dir"),
+        checkpoint_file=touch("this/is/the/checkpoint.txt"),
     params:
         input_files=lambda wildcards, input: ",".join(input.files),
     localrule: True
-    message: "Splitting foo_rule main into chunks"
+    message: "Splitting this_is_a_checkpoint_rule into chunks"
     run:
-        splitter_utils.this_is_a_splitter(
+        splitter_utils.my_splitter(
             input_files=list(input.files),
             output_dir=output.output_dir,
             desired_chunk_size_mb=0.1,

--- a/tests/unit/rule_strings/embarrassingly_parallel_rule.txt
+++ b/tests/unit/rule_strings/embarrassingly_parallel_rule.txt
@@ -5,6 +5,7 @@ rule:
     input:
         dummy_container_main_input_file_paths=['some/path/to/input_chunks/{chunk}/result.parquet'],
         dummy_container_secondary_input_file_paths=['bar'],
+        validations=['baz'],
     output: ['some/path/to/processed/{chunk}/result.parquet']
     log: "spam/foo_rule-output-{chunk}.log"
     container: "Multipolarity.sif"

--- a/tests/unit/rule_strings/pipeline_local.txt
+++ b/tests/unit/rule_strings/pipeline_local.txt
@@ -82,66 +82,27 @@ rule:
         '''
 rule:
     name: "step_3_python_pandas_step_3_main_input_validator"
-    input: ['intermediate/step_2_python_pandas/result.parquet']
-    output: touch("input_validations/step_3_python_pandas/step_3_main_input_validator")
+    input: ['intermediate/step_3_step_3_main_input_split/{chunk}/result.parquet']
+    output: touch("input_validations/step_3_python_pandas/step_3_main_input_validator-{chunk}")
     localrule: True         
     message: "Validating step_3_python_pandas input slot step_3_main_input"
     run:
         for f in input:
             validation_utils.validate_input_file_dummy(f)
-checkpoint:
-    name: "split_step_3_python_pandas_step_3_main_input"
-    input: 
-        files=['intermediate/step_2_python_pandas/result.parquet'],
-        validations=['input_validations/step_3_python_pandas/step_3_main_input_validator'],
-    output: 
-        output_dir=directory("intermediate/step_3_python_pandas/input_chunks"),
-        checkpoint_file=touch("intermediate/step_3_python_pandas/input_chunks/checkpoint.txt"),
-    params:
-        input_files=lambda wildcards, input: ",".join(input.files),
-    localrule: True
-    message: "Splitting step_3_python_pandas step_3_main_input into chunks"
-    run:
-        splitter_utils.split_data_by_size(
-            input_files=list(input.files),
-            output_dir=output.output_dir,
-            desired_chunk_size_mb=0.1,
-        )
-def get_aggregation_inputs_step_3_python_pandas_step_3_main_output(wildcards):
-    checkpoint_file = "intermediate/step_3_python_pandas/input_chunks/checkpoint.txt"
-    if not os.path.exists(checkpoint_file):
-        output, _ = checkpoints.split_step_3_python_pandas_step_3_main_input.rule.expand_output(wildcards)
-        raise IncompleteCheckpointException(checkpoints.split_step_3_python_pandas_step_3_main_input.rule, checkpoint_target(output[0]))
-    checkpoint_output = glob.glob(f"{checkpoints.split_step_3_python_pandas_step_3_main_input.get(**wildcards).output.output_dir}/*/")
-    chunks = [Path(filepath).parts[-1] for filepath in checkpoint_output]
-    return expand(
-        "intermediate/step_3_python_pandas/processed/{chunk}/result.parquet",
-        chunk=chunks
-    )
-rule:
-    name: "aggregate_step_3_python_pandas_step_3_main_output"
-    input: get_aggregation_inputs_step_3_python_pandas_step_3_main_output
-    output: ['intermediate/step_3_python_pandas/result.parquet']
-    localrule: True
-    message: "Aggregating step_3_python_pandas step_3_main_output"
-    run:
-        aggregator_utils.concatenate_datasets(
-            input_files=list(input),
-            output_filepath="intermediate/step_3_python_pandas/result.parquet",
-        )
 rule:
     name: "step_3_python_pandas"
     message: "Running step_3 implementation: step_3_python_pandas"
     input:
-        dummy_container_main_input_file_paths=['intermediate/step_3_python_pandas/input_chunks/{chunk}/result.parquet'],        
-    output: ['intermediate/step_3_python_pandas/processed/{chunk}/result.parquet']
+        dummy_container_main_input_file_paths=['intermediate/step_3_step_3_main_input_split/{chunk}/result.parquet'],
+        validations=['input_validations/step_3_python_pandas/step_3_main_input_validator-{chunk}'], 
+    output: ['intermediate/step_3_python_pandas/{chunk}/result.parquet']
     log: "diagnostics/step_3_python_pandas/step_3_python_pandas-output-{chunk}.log"
     container: "/mnt/team/simulation_science/priv/engineering/er_ecosystem/images/python_pandas.sif"
     shell:
         '''
-        export DUMMY_CONTAINER_OUTPUT_PATHS=intermediate/step_3_python_pandas/processed/{wildcards.chunk}/result.parquet
+        export DUMMY_CONTAINER_OUTPUT_PATHS=intermediate/step_3_python_pandas/{wildcards.chunk}/result.parquet
         export DUMMY_CONTAINER_DIAGNOSTICS_DIRECTORY=diagnostics/step_3_python_pandas
-        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_python_pandas/input_chunks/{wildcards.chunk}/result.parquet
+        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_step_3_main_input_split/{wildcards.chunk}/result.parquet
         python /dummy_step.py > {log} 2>&1
         '''
 rule:
@@ -155,7 +116,7 @@ rule:
             validation_utils.validate_input_file_dummy(f)
 rule:
     name: "step_4_python_pandas_step_4_main_input_validator"
-    input: ['intermediate/step_3_python_pandas/result.parquet']
+    input: ['intermediate/step_3_aggregate/result.parquet']
     output: touch("input_validations/step_4_python_pandas/step_4_main_input_validator")
     localrule: True         
     message: "Validating step_4_python_pandas input slot step_4_main_input"
@@ -167,7 +128,7 @@ rule:
     message: "Running step_4 implementation: step_4_python_pandas"
     input:
         dummy_container_secondary_input_file_paths=['{test_dir}/input_data1/file1.csv', '{test_dir}/input_data2/file2.csv'],
-        dummy_container_main_input_file_paths=['intermediate/step_3_python_pandas/result.parquet'],
+        dummy_container_main_input_file_paths=['intermediate/step_3_aggregate/result.parquet'],
         validations=['input_validations/step_4_python_pandas/step_4_secondary_input_validator', 'input_validations/step_4_python_pandas/step_4_main_input_validator'],
     output: ['intermediate/step_4_python_pandas/result.parquet']
     log: "diagnostics/step_4_python_pandas/step_4_python_pandas-output.log"
@@ -177,7 +138,46 @@ rule:
         export DUMMY_CONTAINER_OUTPUT_PATHS=intermediate/step_4_python_pandas/result.parquet
         export DUMMY_CONTAINER_DIAGNOSTICS_DIRECTORY=diagnostics/step_4_python_pandas
         export DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS={test_dir}/input_data1/file1.csv,{test_dir}/input_data2/file2.csv
-        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_python_pandas/result.parquet
+        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_aggregate/result.parquet
         export INPUT_ENV_VARS=DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS,DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS
         python /dummy_step.py > {log} 2>&1
         '''
+checkpoint:
+    name: "step_3_step_3_main_input_split"
+    input: 
+        files=['intermediate/step_2_python_pandas/result.parquet'],
+    output: 
+        output_dir=directory("intermediate/step_3_step_3_main_input_split"),
+        checkpoint_file=touch("intermediate/step_3_step_3_main_input_split/checkpoint.txt"),
+    params:
+        input_files=lambda wildcards, input: ",".join(input.files),
+    localrule: True
+    message: "Splitting step_3_step_3_main_input_split into chunks"
+    run:
+        splitter_utils.split_data_by_size(
+            input_files=list(input.files),
+            output_dir=output.output_dir,
+            desired_chunk_size_mb=0.1,
+        )
+def get_aggregation_inputs_step_3_aggregate_step_3_main_output(wildcards):
+    checkpoint_file = "intermediate/step_3_step_3_main_input_split/checkpoint.txt"
+    if not os.path.exists(checkpoint_file):
+        output, _ = checkpoints.step_3_step_3_main_input_split.rule.expand_output(wildcards)
+        raise IncompleteCheckpointException(checkpoints.step_3_step_3_main_input_split.rule, checkpoint_target(output[0]))
+    checkpoint_output = glob.glob(f"{checkpoints.step_3_step_3_main_input_split.get(**wildcards).output.output_dir}/*/")
+    chunks = [Path(filepath).parts[-1] for filepath in checkpoint_output]
+    return expand(
+        "intermediate/step_3_python_pandas/{chunk}/result.parquet",
+        chunk=chunks
+    )
+rule:
+    name: "step_3_aggregate_step_3_main_output"
+    input: get_aggregation_inputs_step_3_aggregate_step_3_main_output
+    output: ['intermediate/step_3_aggregate/result.parquet']
+    localrule: True
+    message: "Aggregating step_3_aggregate_step_3_main_output"
+    run:
+        aggregator_utils.concatenate_datasets(
+            input_files=list(input),
+            output_filepath="intermediate/step_3_aggregate/result.parquet",
+        )

--- a/tests/unit/rule_strings/pipeline_slurm.txt
+++ b/tests/unit/rule_strings/pipeline_slurm.txt
@@ -94,59 +94,20 @@ rule:
         '''
 rule:
     name: "step_3_python_pandas_step_3_main_input_validator"
-    input: ['intermediate/step_2_python_pandas/result.parquet']
-    output: touch("input_validations/step_3_python_pandas/step_3_main_input_validator")
+    input: ['intermediate/step_3_step_3_main_input_split/{chunk}/result.parquet']
+    output: touch("input_validations/step_3_python_pandas/step_3_main_input_validator-{chunk}")
     localrule: True         
     message: "Validating step_3_python_pandas input slot step_3_main_input"
     run:
         for f in input:
             validation_utils.validate_input_file_dummy(f)
-checkpoint:
-    name: "split_step_3_python_pandas_step_3_main_input"
-    input: 
-        files=['intermediate/step_2_python_pandas/result.parquet'],
-        validations=['input_validations/step_3_python_pandas/step_3_main_input_validator'],
-    output: 
-        output_dir=directory("intermediate/step_3_python_pandas/input_chunks"),
-        checkpoint_file=touch("intermediate/step_3_python_pandas/input_chunks/checkpoint.txt"),
-    params:
-        input_files=lambda wildcards, input: ",".join(input.files),
-    localrule: True
-    message: "Splitting step_3_python_pandas step_3_main_input into chunks"
-    run:
-        splitter_utils.split_data_by_size(
-            input_files=list(input.files),
-            output_dir=output.output_dir,
-            desired_chunk_size_mb=0.1,
-        )
-def get_aggregation_inputs_step_3_python_pandas_step_3_main_output(wildcards):
-    checkpoint_file = "intermediate/step_3_python_pandas/input_chunks/checkpoint.txt"
-    if not os.path.exists(checkpoint_file):
-        output, _ = checkpoints.split_step_3_python_pandas_step_3_main_input.rule.expand_output(wildcards)
-        raise IncompleteCheckpointException(checkpoints.split_step_3_python_pandas_step_3_main_input.rule, checkpoint_target(output[0]))
-    checkpoint_output = glob.glob(f"{checkpoints.split_step_3_python_pandas_step_3_main_input.get(**wildcards).output.output_dir}/*/")
-    chunks = [Path(filepath).parts[-1] for filepath in checkpoint_output]
-    return expand(
-        "intermediate/step_3_python_pandas/processed/{chunk}/result.parquet",
-        chunk=chunks
-    )
-rule:
-    name: "aggregate_step_3_python_pandas_step_3_main_output"
-    input: get_aggregation_inputs_step_3_python_pandas_step_3_main_output
-    output: ['intermediate/step_3_python_pandas/result.parquet']
-    localrule: True
-    message: "Aggregating step_3_python_pandas step_3_main_output"
-    run:
-        aggregator_utils.concatenate_datasets(
-            input_files=list(input),
-            output_filepath="intermediate/step_3_python_pandas/result.parquet",
-        )
 rule:
     name: "step_3_python_pandas"
     message: "Running step_3 implementation: step_3_python_pandas"
     input:
-        dummy_container_main_input_file_paths=['intermediate/step_3_python_pandas/input_chunks/{chunk}/result.parquet'],        
-    output: ['intermediate/step_3_python_pandas/processed/{chunk}/result.parquet']
+        dummy_container_main_input_file_paths=['intermediate/step_3_step_3_main_input_split/{chunk}/result.parquet'],
+        validations=['input_validations/step_3_python_pandas/step_3_main_input_validator-{chunk}'],        
+    output: ['intermediate/step_3_python_pandas/{chunk}/result.parquet']
     log: "diagnostics/step_3_python_pandas/step_3_python_pandas-output-{chunk}.log"
     container: "/mnt/team/simulation_science/priv/engineering/er_ecosystem/images/python_pandas.sif"
     resources:
@@ -157,9 +118,9 @@ rule:
         slurm_extra="--output 'diagnostics/step_3_python_pandas/step_3_python_pandas-slurm-%j.log'"
     shell:
         '''
-        export DUMMY_CONTAINER_OUTPUT_PATHS=intermediate/step_3_python_pandas/processed/{wildcards.chunk}/result.parquet
+        export DUMMY_CONTAINER_OUTPUT_PATHS=intermediate/step_3_python_pandas/{wildcards.chunk}/result.parquet
         export DUMMY_CONTAINER_DIAGNOSTICS_DIRECTORY=diagnostics/step_3_python_pandas
-        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_python_pandas/input_chunks/{wildcards.chunk}/result.parquet
+        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_step_3_main_input_split/{wildcards.chunk}/result.parquet
         python /dummy_step.py > {log} 2>&1
         '''
 rule:
@@ -173,7 +134,7 @@ rule:
             validation_utils.validate_input_file_dummy(f)
 rule:
     name: "step_4_python_pandas_step_4_main_input_validator"
-    input: ['intermediate/step_3_python_pandas/result.parquet']
+    input: ['intermediate/step_3_aggregate/result.parquet']
     output: touch("input_validations/step_4_python_pandas/step_4_main_input_validator")
     localrule: True         
     message: "Validating step_4_python_pandas input slot step_4_main_input"
@@ -185,7 +146,7 @@ rule:
     message: "Running step_4 implementation: step_4_python_pandas"
     input:
         dummy_container_secondary_input_file_paths=['{test_dir}/input_data1/file1.csv', '{test_dir}/input_data2/file2.csv'],
-        dummy_container_main_input_file_paths=['intermediate/step_3_python_pandas/result.parquet'],
+        dummy_container_main_input_file_paths=['intermediate/step_3_aggregate/result.parquet'],
         validations=['input_validations/step_4_python_pandas/step_4_secondary_input_validator', 'input_validations/step_4_python_pandas/step_4_main_input_validator'],
     output: ['intermediate/step_4_python_pandas/result.parquet']
     log: "diagnostics/step_4_python_pandas/step_4_python_pandas-output.log"
@@ -201,7 +162,46 @@ rule:
         export DUMMY_CONTAINER_OUTPUT_PATHS=intermediate/step_4_python_pandas/result.parquet
         export DUMMY_CONTAINER_DIAGNOSTICS_DIRECTORY=diagnostics/step_4_python_pandas
         export DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS={test_dir}/input_data1/file1.csv,{test_dir}/input_data2/file2.csv
-        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_python_pandas/result.parquet
+        export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=intermediate/step_3_aggregate/result.parquet
         export INPUT_ENV_VARS=DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS,DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS
         python /dummy_step.py > {log} 2>&1
         '''
+checkpoint:
+    name: "step_3_step_3_main_input_split"
+    input: 
+        files=['intermediate/step_2_python_pandas/result.parquet'],
+    output: 
+        output_dir=directory("intermediate/step_3_step_3_main_input_split"),
+        checkpoint_file=touch("intermediate/step_3_step_3_main_input_split/checkpoint.txt"),
+    params:
+        input_files=lambda wildcards, input: ",".join(input.files),
+    localrule: True
+    message: "Splitting step_3_step_3_main_input_split into chunks"
+    run:
+        splitter_utils.split_data_by_size(
+            input_files=list(input.files),
+            output_dir=output.output_dir,
+            desired_chunk_size_mb=0.1,
+        )
+def get_aggregation_inputs_step_3_aggregate_step_3_main_output(wildcards):
+    checkpoint_file = "intermediate/step_3_step_3_main_input_split/checkpoint.txt"
+    if not os.path.exists(checkpoint_file):
+        output, _ = checkpoints.step_3_step_3_main_input_split.rule.expand_output(wildcards)
+        raise IncompleteCheckpointException(checkpoints.step_3_step_3_main_input_split.rule, checkpoint_target(output[0]))
+    checkpoint_output = glob.glob(f"{checkpoints.step_3_step_3_main_input_split.get(**wildcards).output.output_dir}/*/")
+    chunks = [Path(filepath).parts[-1] for filepath in checkpoint_output]
+    return expand(
+        "intermediate/step_3_python_pandas/{chunk}/result.parquet",
+        chunk=chunks
+    )
+rule:
+    name: "step_3_aggregate_step_3_main_output"
+    input: get_aggregation_inputs_step_3_aggregate_step_3_main_output
+    output: ['intermediate/step_3_aggregate/result.parquet']
+    localrule: True
+    message: "Aggregating step_3_aggregate_step_3_main_output"
+    run:
+        aggregator_utils.concatenate_datasets(
+            input_files=list(input),
+            output_filepath="intermediate/step_3_aggregate/result.parquet",
+        )

--- a/tests/unit/test_graph_components.py
+++ b/tests/unit/test_graph_components.py
@@ -34,31 +34,6 @@ def test_input_slot_hashing() -> None:
     assert slot == slot_dupe
     assert {slot, slot_dupe} == {slot}
 
-    slot_with_splitter = InputSlot("slot", "foo", validate_input_file_dummy, dummy_splitter)
-
-    assert slot != slot_with_splitter
-    assert {slot, slot_with_splitter, slot, slot_with_splitter} == {
-        slot,
-        slot_with_splitter,
-    }
-
-    slot_with_different_splitter = InputSlot(
-        "slot", "foo", validate_input_file_dummy, dummy_splitter_2
-    )
-    assert slot_with_splitter != slot_with_different_splitter
-    assert {
-        slot,
-        slot_dupe,
-        slot_with_splitter,
-        slot_with_different_splitter,
-        slot_with_splitter,
-        slot_with_different_splitter,
-    } == {
-        slot,
-        slot_with_splitter,
-        slot_with_different_splitter,
-    }
-
     slot_with_different_validator = InputSlot("slot", "foo", dummy_validator)
     assert slot != slot_with_different_validator
     assert {slot, slot_dupe, slot_with_different_validator} == {
@@ -73,46 +48,12 @@ def test_output_slot_hashing() -> None:
     assert slot == slot_dupe
     assert {slot, slot_dupe} == {slot}
 
-    slot_with_aggregator = OutputSlot("slot", dummy_aggregator)
 
-    assert slot != slot_with_aggregator
-    assert {slot, slot_with_aggregator, slot, slot_with_aggregator} == {
-        slot,
-        slot_with_aggregator,
-    }
-
-    slot_with_different_aggregator = OutputSlot("slot", dummy_aggregator_2)
-    assert slot_with_aggregator != slot_with_different_aggregator
-    assert {
-        slot,
-        slot_dupe,
-        slot_with_aggregator,
-        slot_with_different_aggregator,
-        slot_with_aggregator,
-        slot_with_different_aggregator,
-    } == {
-        slot,
-        slot_with_aggregator,
-        slot_with_different_aggregator,
-    }
-
-    input_slot = InputSlot("slot", "foo", validate_input_file_dummy)
-
-
-def test_slot_mutability() -> None:
+def test_input_slot_mutability() -> None:
     slot = InputSlot("slot", "foo", validate_input_file_dummy)
-    assert slot.splitter is None
-    slot.splitter = dummy_splitter
-    assert slot.splitter == dummy_splitter
-    slot.splitter = dummy_splitter_2
-    assert slot.splitter == dummy_splitter_2
-
-    slot = OutputSlot("slot")
-    assert slot.aggregator is None
-    slot.aggregator = dummy_aggregator
-    assert slot.aggregator == dummy_aggregator
-    slot.aggregator = dummy_aggregator_2
-    assert slot.aggregator == dummy_aggregator_2
+    assert slot.validator == validate_input_file_dummy
+    slot.validator = dummy_validator
+    assert slot.validator == dummy_validator
 
 
 def test_edge() -> None:

--- a/tests/unit/test_pipeline_schema.py
+++ b/tests/unit/test_pipeline_schema.py
@@ -71,7 +71,9 @@ def test_pipeline_schema_get_implementation_graph(default_config) -> None:
         "input_data",
         "step_1_python_pandas",
         "step_2_python_pandas",
+        "step_3_step_3_main_input_split",
         "step_3_python_pandas",
+        "step_3_aggregate",
         "step_4_python_pandas",
         "results",
     ]
@@ -117,30 +119,48 @@ def test_pipeline_schema_get_implementation_graph(default_config) -> None:
         ),
         (
             "step_2_python_pandas",
-            "step_3_python_pandas",
+            "step_3_step_3_main_input_split",
             {
                 "output_slot": OutputSlot("step_2_main_output"),
                 "input_slot": InputSlot(
                     name="step_3_main_input",
+                    env_var=None,
+                    validator=None,
+                ),
+                "filepaths": None,
+            },
+        ),
+        (
+            "step_3_step_3_main_input_split",
+            "step_3_python_pandas",
+            {
+                "output_slot": OutputSlot("step_3_step_3_main_input_split_main_output"),
+                "input_slot": InputSlot(
+                    name="step_3_main_input",
                     env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
                     validator=validate_input_file_dummy,
-                    splitter=split_data_by_size,
-                    splitter_origin_node="step_3",
-                    splitter_origin_slot="step_3_main_input",
                 ),
                 "filepaths": None,
             },
         ),
         (
             "step_3_python_pandas",
+            "step_3_aggregate",
+            {
+                "output_slot": OutputSlot("step_3_main_output"),
+                "input_slot": InputSlot(
+                    name="step_3_aggregate_main_input",
+                    env_var=None,
+                    validator=None,
+                ),
+                "filepaths": None,
+            },
+        ),
+        (
+            "step_3_aggregate",
             "step_4_python_pandas",
             {
-                "output_slot": OutputSlot(
-                    "step_3_main_output",
-                    aggregator=concatenate_datasets,
-                    splitter_origin_node="step_3",
-                    splitter_origin_slot="step_3_main_input",
-                ),
+                "output_slot": OutputSlot("step_3_main_output"),
                 "input_slot": InputSlot(
                     name="step_4_main_input",
                     env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -159,29 +159,27 @@ def test_embarrassingly_parallel_rule_build_rule_multiple_outputs_raises():
         rule.build_rule()
 
 
-def test_checkpoint_build_rule():
+def test_checkpoint_rule_build_rule():
     rule = CheckpointRule(
-        name="foo_rule",
+        name="this_is_a_checkpoint_rule",
         input_files=["some/input/file1", "some/input/file2"],
-        input_slot_to_split="main",
-        splitter_name="this_is_a_splitter",
-        validations=["baz"],
-        output_dir="some/path/to/quux",
+        splitter_func_name="my_splitter",
+        output_dir="this/is/the/output/dir",
+        checkpoint_filepath="this/is/the/checkpoint.txt",
     )
 
     file_path = Path(os.path.dirname(__file__)) / RULE_STRINGS["checkpoint_rule"]
     _check_rule(rule, file_path)
 
 
-def test_aggregation_build_rule():
+def test_aggregation_rule_build_rule():
     rule = AggregationRule(
-        name="foo_rule",
-        input_files="these/are/processed/{chunk}",
-        output_slot_name="main_output",
-        aggregated_output_file="some/path/to/results/result.parquet",
-        aggregator_name=_dummy_aggregator.__name__,
+        name="this_is_an_aggregation_rule",
+        input_files="these/are/processed/{chunk}/result.parquet",
+        aggregated_output_file="some/path/to/aggregated/results/result.parquet",
+        aggregator_func_name="my_aggregator",
         checkpoint_filepath="this/is/the/checkpoint.txt",
-        checkpoint_rule_name="checkpoints.split_some_split_node_some_split_slot",
+        checkpoint_rule_name="checkpoints.this_is_a_checkpoint_rule",
     )
 
     file_path = Path(os.path.dirname(__file__)) / RULE_STRINGS["aggregation_rule"]

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1832,9 +1832,11 @@ def _check_embarrassingly_parallel_details(
         == list(ep_step.slot_splitter_mapping.values())[0].__name__
     )
     # check aggregator node has aggregator mappings and also points to splitter
+    implementation = nodes[aggregator_node_name]["implementation"]
+    output_slot_name = list(implementation.output_slots.keys())[0]
     assert (
-        nodes[aggregator_node_name]["implementation"].slot_aggregator_mapping
-        == ep_step.slot_aggregator_mapping
+        implementation.aggregator_func_name
+        == ep_step.slot_aggregator_mapping[output_slot_name].__name__
     )
     assert (
         nodes[aggregator_node_name]["implementation"].splitter_node_name == splitter_node_name

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -118,6 +118,13 @@ def test_basic_step_implementation_graph(
     )
 
 
+def test_basic_step_missing_names_raises() -> None:
+    with pytest.raises(
+        ValueError, match="All Steps must contain a step_name, name, or both."
+    ):
+        Step(step_name=None)
+
+
 @pytest.fixture
 def hierarchical_step_params() -> dict[str, Any]:
     return {

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1838,7 +1838,7 @@ def _check_embarrassingly_parallel_details(
         == ep_step.slot_aggregator_mapping
     )
     assert (
-        nodes[aggregator_node_name]["implementation"].splitter_step_name == splitter_node_name
+        nodes[aggregator_node_name]["implementation"].splitter_node_name == splitter_node_name
     )
     # check the rest are embarrassingly parallel
     for node in implemented_node_names:

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -1209,7 +1209,7 @@ def test_embarrassingly_parallel_step_implementation_graph(
         ),
     ]
     _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
-    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
+    _check_embarrassingly_parallel_details(implementation_graph, ep_step)
 
 
 @pytest.mark.parametrize(
@@ -1518,7 +1518,7 @@ def test_embarrassingly_parallel_hierarchical_step_implementation_graph(
         ),
     ]
     _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
-    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
+    _check_embarrassingly_parallel_details(implementation_graph, ep_step)
 
 
 @pytest.fixture
@@ -1639,7 +1639,7 @@ def test_embarrassingly_parallel_loop_step_implementation_graph(
         ),
     ]
     _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
-    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
+    _check_embarrassingly_parallel_details(implementation_graph, ep_step)
 
 
 @pytest.fixture
@@ -1790,7 +1790,7 @@ def test_embarrassingly_parallel_parallel_step_implementation_graph(
         ),
     ]
     _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
-    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
+    _check_embarrassingly_parallel_details(implementation_graph, ep_step)
 
 
 ####################
@@ -1818,7 +1818,6 @@ def _check_nodes_and_edges(
 
 def _check_embarrassingly_parallel_details(
     implementation_graph: ImplementationGraph,
-    expected_nodes: list[str],
     ep_step: EmbarrassinglyParallelStep,
 ) -> None:
     nodes = implementation_graph.nodes

--- a/tests/unit/test_step.py
+++ b/tests/unit/test_step.py
@@ -91,8 +91,7 @@ def test_io_step_slots(io_step_params: dict[str, Any]) -> None:
 def test_io_implementation_graph(io_step_params: dict[str, Any]) -> None:
     step = IOStep(**io_step_params)
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == ["io"]
-    assert list(implementation_graph.edges) == []
+    _check_nodes_and_edges(implementation_graph, expected_nodes=["io"], expected_edges=[])
 
 
 def test_basic_step_slots(basic_step_params: dict[str, Any]) -> None:
@@ -114,8 +113,9 @@ def test_basic_step_implementation_graph(
     step = Step(**basic_step_params)
     step.set_configuration_state(default_config["pipeline"]["steps"][step.name], {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == ["step_1_python_pandas"]
-    assert list(implementation_graph.edges) == []
+    _check_nodes_and_edges(
+        implementation_graph, expected_nodes=["step_1_python_pandas"], expected_edges=[]
+    )
 
 
 @pytest.fixture
@@ -188,8 +188,9 @@ def test_hierarchical_step_implementation_graph(
     )
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == ["step_4_python_pandas"]
-    assert list(implementation_graph.edges) == []
+    _check_nodes_and_edges(
+        implementation_graph, expected_nodes=["step_4_python_pandas"], expected_edges=[]
+    )
 
     # Test implementation_graph for substeps
     step_config = LayeredConfigTree(
@@ -212,7 +213,7 @@ def test_hierarchical_step_implementation_graph(
     )
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
         "step_4a_python_pandas",
         "step_4b_python_pandas",
     ]
@@ -231,9 +232,7 @@ def test_hierarchical_step_implementation_graph(
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
 
 
 @pytest.fixture
@@ -366,8 +365,9 @@ def test_loop_implementation_graph(
     step = LoopStep(**loop_step_params)
     step.set_configuration_state(default_config["pipeline"]["steps"][step.name], {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == ["step_3_python_pandas"]
-    assert list(implementation_graph.edges) == []
+    _check_nodes_and_edges(
+        implementation_graph, expected_nodes=["step_3_python_pandas"], expected_edges=[]
+    )
 
     step_config = LayeredConfigTree(
         {
@@ -399,7 +399,7 @@ def test_loop_implementation_graph(
     )
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
         "step_3_loop_1_step_3_python_pandas",
         "step_3_loop_2_step_3a_step_3a_python_pandas",
         "step_3_loop_2_step_3b_step_3b_python_pandas",
@@ -432,9 +432,7 @@ def test_loop_implementation_graph(
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
 
 
 @pytest.fixture
@@ -602,7 +600,7 @@ def test_parallel_step_implementation_graph(
     )
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert set(implementation_graph.nodes) == {
+    expected_nodes = {
         "step_1_parallel_split_1_step_1a_step_1a_python_pandas",
         "step_1_parallel_split_1_step_1b_step_1b_python_pandas",
         "step_1_parallel_split_2_step_1a_step_1a_python_pandas",
@@ -651,9 +649,7 @@ def test_parallel_step_implementation_graph(
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
 
 
 @pytest.mark.parametrize("step_type", ["parallel", "loop"])
@@ -690,10 +686,10 @@ def test_templated_implementation_graph_no_multiplicity(
     )
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert set(implementation_graph.nodes) == {
+    expected_nodes = [
         f"{step.name}a_python_pandas",
         f"{step.name}b_python_pandas",
-    }
+    ]
     expected_edges = [
         (
             f"{step.name}a_python_pandas",
@@ -709,9 +705,7 @@ def test_templated_implementation_graph_no_multiplicity(
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
 
 
 @pytest.mark.parametrize("step_type", ["loop", "parallel"])
@@ -1019,8 +1013,9 @@ def test_simple_choice_step_implementation_graph(choice_step_params: dict[str, A
     step.validate_step(step_config, {}, {})
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == ["step_4_python_pandas"]
-    assert list(implementation_graph.edges) == []
+    _check_nodes_and_edges(
+        implementation_graph, expected_nodes=["step_4_python_pandas"], expected_edges=[]
+    )
 
     # Test implementation_graph for a step with substeps
     step_config = LayeredConfigTree(
@@ -1044,7 +1039,7 @@ def test_simple_choice_step_implementation_graph(choice_step_params: dict[str, A
     )
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
         "step_4a_python_pandas",
         "step_4b_r",
     ]
@@ -1063,9 +1058,7 @@ def test_simple_choice_step_implementation_graph(choice_step_params: dict[str, A
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
 
 
 def test_complex_choice_step_implementation_graph(choice_step_params: dict[str, Any]) -> None:
@@ -1103,7 +1096,7 @@ def test_complex_choice_step_implementation_graph(choice_step_params: dict[str, 
     step.validate_step(step_config, {}, {})
     step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
         "step_5_python_pandas",
         "step_6_loop_1_step_6_python_pandas",
         "step_6_loop_2_step_6_python_pandas",
@@ -1136,9 +1129,7 @@ def test_complex_choice_step_implementation_graph(choice_step_params: dict[str, 
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
 
 
 @pytest.fixture
@@ -1155,8 +1146,8 @@ def embarrassingly_parallel_step_params() -> dict[str, Any]:
             ],
             output_slots=[OutputSlot("step_3_main_output")],
         ),
-        "splitter": {"step_3_main_input": split_data_by_size},
-        "aggregator": {"step_3_main_output": concatenate_datasets},
+        "slot_splitter_mapping": {"step_3_main_input": split_data_by_size},
+        "slot_aggregator_mapping": {"step_3_main_output": concatenate_datasets},
     }
 
 
@@ -1170,11 +1161,10 @@ def test_embarrassingly_parallel_step_slots(
             "step_3_main_input",
             "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
             validate_input_file_dummy,
-            split_data_by_size,
         ),
     }
     assert step.output_slots == {
-        "step_3_main_output": OutputSlot("step_3_main_output", concatenate_datasets),
+        "step_3_main_output": OutputSlot("step_3_main_output"),
     }
 
 
@@ -1185,20 +1175,45 @@ def test_embarrassingly_parallel_step_implementation_graph(
     step_config = LayeredConfigTree({"implementation": {"name": "step_3_python_pandas"}})
     ep_step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(ep_step)
-    assert list(implementation_graph.nodes) == ["step_3_python_pandas"]
-    assert list(implementation_graph.edges) == []
-
-    # Check that the implementation has the splitter and aggregator
-    implementation = implementation_graph.nodes["step_3_python_pandas"]["implementation"]
-    assert implementation.input_slots["step_3_main_input"].splitter == split_data_by_size
-    assert (
-        implementation.output_slots["step_3_main_output"].aggregator == concatenate_datasets
-    )
-    assert implementation.is_embarrassingly_parallel
+    expected_nodes = [
+        "step_3_step_3_main_input_split",
+        "step_3_python_pandas",
+        "step_3_aggregate",
+    ]
+    expected_edges = [
+        (
+            "step_3_step_3_main_input_split",
+            "step_3_python_pandas",
+            {
+                "input_slot": InputSlot(
+                    "step_3_main_input",
+                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validator=validate_input_file_dummy,
+                ),
+                "output_slot": OutputSlot("step_3_step_3_main_input_split_main_output"),
+                "filepaths": None,
+            },
+        ),
+        (
+            "step_3_python_pandas",
+            "step_3_aggregate",
+            {
+                "input_slot": InputSlot(
+                    "step_3_aggregate_main_input",
+                    env_var=None,
+                    validator=None,
+                ),
+                "output_slot": OutputSlot("step_3_main_output"),
+                "filepaths": None,
+            },
+        ),
+    ]
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
+    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
 
 
 @pytest.mark.parametrize(
-    "input_slots, output_slots, splitter, aggregator, expected_error_msg",
+    "input_slots, output_slots, slot_splitter_mapping, slot_aggregator_mapping, expected_error_msg",
     [
         (
             [
@@ -1256,7 +1271,7 @@ def test_embarrassingly_parallel_step_implementation_graph(
                 ),
             ],
             [
-                OutputSlot("main_output", concatenate_datasets),
+                OutputSlot("main_output"),
                 OutputSlot("secondary_output"),
             ],
             {},
@@ -1272,17 +1287,15 @@ def test_embarrassingly_parallel_step_implementation_graph(
                     "main_input",
                     "FOO",
                     validate_input_file_dummy,
-                    split_data_by_size,
                 ),
                 InputSlot(
                     "secondary_input",
                     "BAR",
                     validate_input_file_dummy,
-                    split_data_by_size,
                 ),
             ],
             [
-                OutputSlot("main_output", concatenate_datasets),
+                OutputSlot("main_output"),
                 OutputSlot("secondary_output"),
             ],
             {"main_input": split_data_by_size, "secondary_input": split_data_by_size},
@@ -1304,8 +1317,8 @@ def test_embarrassingly_parallel_step_implementation_graph(
 def test_embarrassingly_parallel_step__validation(
     input_slots: list[InputSlot],
     output_slots: list[OutputSlot],
-    splitter: dict[str, Callable],
-    aggregator: dict[str, Callable],
+    slot_splitter_mapping: dict[str, Callable],
+    slot_aggregator_mapping: dict[str, Callable],
     expected_error_msg: str | list[str],
 ):
     step_params = {
@@ -1314,8 +1327,8 @@ def test_embarrassingly_parallel_step__validation(
             input_slots=input_slots,
             output_slots=output_slots,
         ),
-        "splitter": splitter,
-        "aggregator": aggregator,
+        "slot_splitter_mapping": slot_splitter_mapping,
+        "slot_aggregator_mapping": slot_aggregator_mapping,
     }
     with pytest.raises(ValueError) as error:
         EmbarrassinglyParallelStep(**step_params)
@@ -1348,7 +1361,6 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
             ],
             output_slots=[
                 OutputSlot("steps_1_2_3_main_output"),
-                OutputSlot("steps_1_2_3_secondary_output"),
             ],
             nodes=[
                 Step(
@@ -1367,7 +1379,6 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
                     ],
                     output_slots=[
                         OutputSlot("step_1_main_output"),
-                        OutputSlot("step_1_secondary_output"),
                     ],
                 ),
                 Step(
@@ -1386,7 +1397,6 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
                     ],
                     output_slots=[
                         OutputSlot("step_2_main_output"),
-                        OutputSlot("step_2_secondary_output"),
                     ],
                 ),
                 Step(
@@ -1405,19 +1415,12 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
                     ],
                     output_slots=[
                         OutputSlot("step_3_main_output"),
-                        OutputSlot("step_3_secondary_output"),
                     ],
                 ),
             ],
             edges=[
                 EdgeParams("step_1", "step_2", "step_1_main_output", "step_2_main_input"),
-                EdgeParams(
-                    "step_1", "step_2", "step_1_secondary_output", "step_2_secondary_input"
-                ),
                 EdgeParams("step_2", "step_3", "step_2_main_output", "step_3_main_input"),
-                EdgeParams(
-                    "step_2", "step_3", "step_2_secondary_output", "step_3_secondary_input"
-                ),
             ],
             input_slot_mappings=[
                 InputSlotMapping("steps_1_2_3_main_input", "step_1", "step_1_main_input"),
@@ -1427,15 +1430,11 @@ def embarrassingly_parallel_hierarchical_step_params() -> dict[str, Any]:
             ],
             output_slot_mappings=[
                 OutputSlotMapping("steps_1_2_3_main_output", "step_3", "step_3_main_output"),
-                OutputSlotMapping(
-                    "steps_1_2_3_secondary_output", "step_3", "step_3_secondary_output"
-                ),
             ],
         ),
-        "splitter": {"steps_1_2_3_main_input": split_data_by_size},
-        "aggregator": {
+        "slot_splitter_mapping": {"steps_1_2_3_main_input": split_data_by_size},
+        "slot_aggregator_mapping": {
             "steps_1_2_3_main_output": concatenate_datasets,
-            "steps_1_2_3_secondary_output": concatenate_datasets,
         },
     }
 
@@ -1455,22 +1454,26 @@ def test_embarrassingly_parallel_hierarchical_step_implementation_graph(
     )
     ep_step.set_configuration_state(step_config, {}, {})
     implementation_graph = _create_implementation_graph(ep_step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
+        "steps_1_2_3_steps_1_2_3_main_input_split",
         "step_1_python_pandas",
         "step_2_python_pandas",
         "step_3_python_pandas",
+        "steps_1_2_3_aggregate",
     ]
     expected_edges = [
         (
+            "steps_1_2_3_steps_1_2_3_main_input_split",
             "step_1_python_pandas",
-            "step_2_python_pandas",
             {
                 "input_slot": InputSlot(
-                    "step_2_main_input",
-                    "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-                    validate_input_file_dummy,
+                    "step_1_main_input",
+                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validator=validate_input_file_dummy,
                 ),
-                "output_slot": OutputSlot("step_1_main_output"),
+                "output_slot": OutputSlot(
+                    "steps_1_2_3_steps_1_2_3_main_input_split_main_output"
+                ),
                 "filepaths": None,
             },
         ),
@@ -1479,11 +1482,11 @@ def test_embarrassingly_parallel_hierarchical_step_implementation_graph(
             "step_2_python_pandas",
             {
                 "input_slot": InputSlot(
-                    "step_2_secondary_input",
-                    "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS",
-                    validate_input_file_dummy,
+                    "step_2_main_input",
+                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validator=validate_input_file_dummy,
                 ),
-                "output_slot": OutputSlot("step_1_secondary_output"),
+                "output_slot": OutputSlot("step_1_main_output"),
                 "filepaths": None,
             },
         ),
@@ -1493,58 +1496,29 @@ def test_embarrassingly_parallel_hierarchical_step_implementation_graph(
             {
                 "input_slot": InputSlot(
                     "step_3_main_input",
-                    "DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
-                    validate_input_file_dummy,
+                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validator=validate_input_file_dummy,
                 ),
                 "output_slot": OutputSlot("step_2_main_output"),
                 "filepaths": None,
             },
         ),
         (
-            "step_2_python_pandas",
             "step_3_python_pandas",
+            "steps_1_2_3_aggregate",
             {
                 "input_slot": InputSlot(
-                    "step_3_secondary_input",
-                    "DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS",
-                    validate_input_file_dummy,
+                    "steps_1_2_3_aggregate_main_input",
+                    env_var=None,
+                    validator=None,
                 ),
-                "output_slot": OutputSlot("step_2_secondary_output"),
+                "output_slot": OutputSlot("step_3_main_output"),
                 "filepaths": None,
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
-
-    # Check that the implementation has the splitter and aggregator
-    imp1 = implementation_graph.nodes["step_1_python_pandas"]["implementation"]
-    assert len(imp1.input_slots) == 2
-    assert imp1.input_slots["step_1_main_input"].splitter == split_data_by_size
-    assert imp1.input_slots["step_1_secondary_input"].splitter == None
-    assert len(imp1.output_slots) == 2
-    assert imp1.output_slots["step_1_main_output"].aggregator == None
-    assert imp1.output_slots["step_1_secondary_output"].aggregator == None
-    assert imp1.is_embarrassingly_parallel
-
-    imp2 = implementation_graph.nodes["step_2_python_pandas"]["implementation"]
-    assert len(imp2.input_slots) == 2
-    assert imp2.input_slots["step_2_main_input"].splitter == None
-    assert imp2.input_slots["step_2_secondary_input"].splitter == None
-    assert len(imp2.output_slots) == 2
-    assert imp2.output_slots["step_2_main_output"].aggregator == None
-    assert imp2.output_slots["step_2_secondary_output"].aggregator == None
-    assert imp2.is_embarrassingly_parallel
-
-    imp3 = implementation_graph.nodes["step_3_python_pandas"]["implementation"]
-    assert len(imp3.input_slots) == 2
-    assert imp3.input_slots["step_3_main_input"].splitter == None
-    assert imp3.input_slots["step_3_secondary_input"].splitter == None
-    assert len(imp3.output_slots) == 2
-    assert imp3.output_slots["step_3_main_output"].aggregator == concatenate_datasets
-    assert imp3.output_slots["step_3_secondary_output"].aggregator == concatenate_datasets
-    assert imp3.is_embarrassingly_parallel
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
+    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
 
 
 @pytest.fixture
@@ -1553,8 +1527,8 @@ def embarrassingly_parallel_loop_step_params(
 ) -> dict[str, Any]:
     return {
         "step": LoopStep(**loop_step_params),
-        "splitter": {"step_3_main_input": split_data_by_size},
-        "aggregator": {"step_3_main_output": concatenate_datasets},
+        "slot_splitter_mapping": {"step_3_main_input": split_data_by_size},
+        "slot_aggregator_mapping": {"step_3_main_output": concatenate_datasets},
     }
 
 
@@ -1587,15 +1561,30 @@ def test_embarrassingly_parallel_loop_step_implementation_graph(
     ep_step.set_configuration_state(step_config, {}, {})
     mocker.patch("easylink.implementation.Implementation._load_metadata")
     implementation_graph = _create_implementation_graph(ep_step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
+        "step_3_step_3_main_input_split",
         "step_3_loop_1_step_3a_step_3a_python_pandas",
         "step_3_loop_1_step_3b_step_3b_python_pandas",
         "step_3_loop_2_step_3_python_pandas",
         "step_3_loop_3_step_3_python_pandas",
+        "step_3_aggregate",
     ]
     # NOTE: There are no internal edges to the secondary slot (they are all
     # mapped from the outer HierarchicalStep defined in the `loop_step_params`)
     expected_edges = [
+        (
+            "step_3_step_3_main_input_split",
+            "step_3_loop_1_step_3a_step_3a_python_pandas",
+            {
+                "input_slot": InputSlot(
+                    "step_3a_main_input",
+                    env_var="DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS",
+                    validator=validate_input_file_dummy,
+                ),
+                "output_slot": OutputSlot("step_3_step_3_main_input_split_main_output"),
+                "filepaths": None,
+            },
+        ),
         (
             "step_3_loop_1_step_3a_step_3a_python_pandas",
             "step_3_loop_1_step_3b_step_3b_python_pandas",
@@ -1635,62 +1624,22 @@ def test_embarrassingly_parallel_loop_step_implementation_graph(
                 "filepaths": None,
             },
         ),
+        (
+            "step_3_loop_3_step_3_python_pandas",
+            "step_3_aggregate",
+            {
+                "input_slot": InputSlot(
+                    "step_3_aggregate_main_input",
+                    env_var=None,
+                    validator=None,
+                ),
+                "output_slot": OutputSlot("step_3_main_output"),
+                "filepaths": None,
+            },
+        ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
-
-    # Check that the implementation has the splitter and aggregator
-    expected_defined = {
-        "is_embarrassingly_parallel": True,
-        "num_input_slots": 2,
-        "num_output_slots": 1,
-        "step_3_loop_1_step_3a_step_3a_python_pandas": {
-            "step_3a_main_input": {
-                "splitter": split_data_by_size,
-                "splitter_origin_node": "step_3",
-                "splitter_origin_slot": "step_3_main_input",
-            },
-            # nothing defined on secondary input slots or the output slot
-        },
-        # nothing defined in step_3_loop_1_step_3b_step_3b_python_pandas
-        # nothing defined in step_3_loop_2_step_3_python_pandas
-        "step_3_loop_3_step_3_python_pandas": {
-            "step_3_main_output": {
-                "aggregator": concatenate_datasets,
-                "splitter_origin_node": "step_3",
-                "splitter_origin_slot": "step_3_main_input",
-            },
-            # nothing defined on the secondary input slot or the output slot
-        },
-    }
-    for node in implementation_graph.nodes:
-        implementation = implementation_graph.nodes[node]["implementation"]
-        assert (
-            implementation.is_embarrassingly_parallel
-            == expected_defined["is_embarrassingly_parallel"]
-        )
-        assert len(implementation.input_slots) == expected_defined["num_input_slots"]
-        assert len(implementation.output_slots) == expected_defined["num_output_slots"]
-        node_expected = expected_defined.get(node, {})
-        for input_slot in implementation.input_slots.values():
-            input_slot_expected = node_expected.get(input_slot.name, {})
-            assert input_slot.splitter == input_slot_expected.get("splitter")
-            assert input_slot.splitter_origin_node == input_slot_expected.get(
-                "splitter_origin_node"
-            )
-            assert input_slot.splitter_origin_slot == input_slot_expected.get(
-                "splitter_origin_slot"
-            )
-        for output_slot in implementation.output_slots.values():
-            output_slot_expected = node_expected.get(output_slot.name, {})
-            assert output_slot.aggregator == output_slot_expected.get("aggregator")
-            assert output_slot.splitter_origin_node == output_slot_expected.get(
-                "splitter_origin_node"
-            )
-            assert output_slot.splitter_origin_slot == output_slot_expected.get(
-                "splitter_origin_slot"
-            )
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
+    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
 
 
 @pytest.fixture
@@ -1733,7 +1682,7 @@ def test_embarrassingly_parallel_parallel_step_implementation_graph(
     ep_step.set_configuration_state(step_config, {}, {})
     mocker.patch("easylink.implementation.Implementation._load_metadata")
     implementation_graph = _create_implementation_graph(ep_step)
-    assert list(implementation_graph.nodes) == [
+    expected_nodes = [
         "step_1_step_1_main_input_split",
         "step_1_parallel_split_1_step_1a_step_1a_python_pandas",
         "step_1_parallel_split_1_step_1b_step_1b_python_pandas",
@@ -1840,50 +1789,8 @@ def test_embarrassingly_parallel_parallel_step_implementation_graph(
             },
         ),
     ]
-    assert len(implementation_graph.edges) == len(expected_edges)
-    for edge in expected_edges:
-        assert edge in implementation_graph.edges(data=True)
-
-    # Check that the correct implementations have the splitter and aggregator
-    imp1_1a = implementation_graph.nodes[
-        "step_1_parallel_split_1_step_1a_step_1a_python_pandas"
-    ]["implementation"]
-    assert len(imp1_1a.input_slots) == 2
-    assert imp1_1a.input_slots["step_1a_main_input"].splitter == split_data_by_size
-    assert imp1_1a.input_slots["step_1a_secondary_input"].splitter == None
-    assert len(imp1_1a.output_slots) == 1
-    assert imp1_1a.output_slots["step_1a_main_output"].aggregator == None
-    assert imp1_1a.is_embarrassingly_parallel
-
-    imp1_1b = implementation_graph.nodes[
-        "step_1_parallel_split_1_step_1b_step_1b_python_pandas"
-    ]["implementation"]
-    assert len(imp1_1b.input_slots) == 2
-    assert imp1_1b.input_slots["step_1b_main_input"].splitter == None
-    assert imp1_1b.input_slots["step_1b_secondary_input"].splitter == None
-    assert len(imp1_1b.output_slots) == 1
-    assert imp1_1b.output_slots["step_1b_main_output"].aggregator == concatenate_datasets
-    assert imp1_1b.is_embarrassingly_parallel
-
-    imp2 = implementation_graph.nodes["step_1_parallel_split_2_step_1_python_pandas"][
-        "implementation"
-    ]
-    assert len(imp2.input_slots) == 2
-    assert imp2.input_slots["step_1_main_input"].splitter == split_data_by_size
-    assert imp2.input_slots["step_1_secondary_input"].splitter == None
-    assert len(imp2.output_slots) == 1
-    assert imp2.output_slots["step_1_main_output"].aggregator == concatenate_datasets
-    assert imp2.is_embarrassingly_parallel
-
-    imp3 = implementation_graph.nodes["step_1_parallel_split_3_step_1_python_pandas"][
-        "implementation"
-    ]
-    assert len(imp3.input_slots) == 2
-    assert imp3.input_slots["step_1_main_input"].splitter == split_data_by_size
-    assert imp3.input_slots["step_1_secondary_input"].splitter == None
-    assert len(imp3.output_slots) == 1
-    assert imp3.output_slots["step_1_main_output"].aggregator == concatenate_datasets
-    assert imp3.is_embarrassingly_parallel
+    _check_nodes_and_edges(implementation_graph, expected_nodes, expected_edges)
+    _check_embarrassingly_parallel_details(implementation_graph, expected_nodes, ep_step)
 
 
 ####################
@@ -1896,3 +1803,43 @@ def _create_implementation_graph(step: Step) -> ImplementationGraph:
     step.add_nodes_to_implementation_graph(implementation_graph)
     step.add_edges_to_implementation_graph(implementation_graph)
     return implementation_graph
+
+
+def _check_nodes_and_edges(
+    implementation_graph: ImplementationGraph,
+    expected_nodes: list[str],
+    expected_edges: list[tuple[str, str, dict[str, InputSlot | OutputSlot | None]]],
+) -> None:
+    assert set(implementation_graph.nodes) == set(expected_nodes)
+    assert len(implementation_graph.edges) == len(expected_edges)
+    for edge in expected_edges:
+        assert edge in implementation_graph.edges(data=True)
+
+
+def _check_embarrassingly_parallel_details(
+    implementation_graph: ImplementationGraph,
+    expected_nodes: list[str],
+    ep_step: EmbarrassinglyParallelStep,
+) -> None:
+    nodes = implementation_graph.nodes
+    splitter_node_name = list(nodes)[0]
+    aggregator_node_name = list(nodes)[-1]
+    implemented_node_names = [
+        node for node in list(nodes) if node not in [splitter_node_name, aggregator_node_name]
+    ]
+    # check splitter node has function defined
+    assert (
+        nodes[splitter_node_name]["implementation"].splitter_func_name
+        == list(ep_step.slot_splitter_mapping.values())[0].__name__
+    )
+    # check aggregator node has aggregator mappings and also points to splitter
+    assert (
+        nodes[aggregator_node_name]["implementation"].slot_aggregator_mapping
+        == ep_step.slot_aggregator_mapping
+    )
+    assert (
+        nodes[aggregator_node_name]["implementation"].splitter_step_name == splitter_node_name
+    )
+    # check the rest are embarrassingly parallel
+    for node in implemented_node_names:
+        assert nodes[node]["implementation"].is_embarrassingly_parallel


### PR DESCRIPTION
## Implement SplitterSteps and AggregatorSteps

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5987
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> We decided it would be easier (and arguably clearer) if an
EmbarrassinglyParallelStep had, by definition, exactly three nodes
in it's stepgraph instead of the current single node:
- a SplitterStep which does the splitting.
- the one and only Step that is being run embarrassingly parallel-y
- an AggregatorStep which does the post-processing aggregation.

In making explicit steps out of splitting and aggregating, we get
- slot mappings for free
- to remove the propagation of the splitter-aggregator link b/c that information
is available which actually constructing the AggregatorStep.
- to move some of the snakemake rule-writing logic up in "real" python-land.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

