### PR TITLE
add double escape to broken sequences

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.15 - 5/5/25**
+
+ - Fix SyntaxWarning for unescaped backslashes
+
 **0.1.14 - 5/1/25**
 
  - Add support for EmbarrassinglyParallelSteps to accept sections (i.e. non-leaf steps)

--- a/src/easylink/utilities/spark.smk
+++ b/src/easylink/utilities/spark.smk
@@ -70,7 +70,7 @@ rule wait_for_spark_master:
         while true; do
 
             if [[ -e {params.spark_master_log_file} ]]; then
-                found=`grep -o "\(spark://.*$\)" {params.spark_master_log_file} || true`
+                found=`grep -o "\\(spark://.*$\\)" {params.spark_master_log_file} || true`
 
                 if [[ ! -z $found ]]; then
                     echo "Spark master URL found: $found"
@@ -178,7 +178,7 @@ rule wait_for_spark_worker:
         while true; do
 
             if [[ -e {params.spark_worker_log_file} ]]; then
-                found=`grep -o "\(Worker: Successfully registered with master $MASTER_URL\)" {params.spark_worker_log_file} || true`
+                found=`grep -o "\\(Worker: Successfully registered with master $MASTER_URL\\)" {params.spark_worker_log_file} || true`
 
                 if [[ ! -z $found ]]; then
                     echo "Spark Worker {wildcards.scatteritem} registered successfully"


### PR DESCRIPTION
## add double escape to broken Spark sequences
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6301
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The Spark .smk file doesn't double escape, so we get lots of 
```
SyntaxWarning: invalid escape sequence '\('
```
Interestingly, this warning seems to have been added in 3.12
I opted to use a double escape instead of a raw string, as in other parts of the file we are using actual escape sequences and it seemed best to be consistent.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->


