### PR TITLE
Add a failing test for an output slot being directory-valued

### DIFF
--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -193,3 +193,17 @@ step_1a_and_step_1b_combined_python_pandas:
   script_cmd: python /dummy_step.py
   outputs:
     step_1_main_output: result.parquet
+dummy_step_1_for_output_dir_example:
+  steps:
+  - step_1_for_output_dir_example
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/dummy_step_1_for_output_dir_example.sif
+  script_cmd: python /dummy_step_1_for_output_dir_example.py
+  outputs:
+    step_1_main_output_directory: output_dir/
+dummy_step_2_for_output_dir_example:
+  steps:
+  - step_2_for_output_dir_example
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/dummy_step_2_for_output_dir_example.sif
+  script_cmd: python /dummy_step_2_for_output_dir_example.py
+  outputs:
+    step_2_main_output: result.parquet

--- a/src/easylink/pipeline_schema_constants/__init__.py
+++ b/src/easylink/pipeline_schema_constants/__init__.py
@@ -17,6 +17,7 @@ ALLOWED_SCHEMA_PARAMS = {
 
 TESTING_SCHEMA_PARAMS = {
     "integration": testing.SCHEMA_PARAMS_ONE_STEP,
+    "output_dir": testing.SCHEMA_PARAMS_OUTPUT_DIR,
     "combine_bad_topology": testing.SCHEMA_PARAMS_BAD_COMBINED_TOPOLOGY,
     "combine_bad_implementation_names": testing.SCHEMA_PARAMS_BAD_COMBINED_TOPOLOGY,
     "nested_templated_steps": testing.SCHEMA_PARAMS_NESTED_TEMPLATED_STEPS,

--- a/src/easylink/pipeline_schema_constants/testing.py
+++ b/src/easylink/pipeline_schema_constants/testing.py
@@ -26,7 +26,7 @@ from easylink.step import (
 )
 from easylink.utilities.aggregator_utils import concatenate_datasets
 from easylink.utilities.splitter_utils import split_data_in_two
-from easylink.utilities.validation_utils import validate_input_file_dummy
+from easylink.utilities.validation_utils import validate_input_file_dummy, validate_dir
 
 NODES_ONE_STEP = [
     InputStep(),
@@ -582,3 +582,55 @@ EDGES_ONE_STEP_TWO_ISLOTS = [
     ),
 ]
 SCHEMA_PARAMS_EP_HIERARCHICAL_STEP = (NODES_EP_HIERARCHICAL_STEP, EDGES_ONE_STEP_TWO_ISLOTS)
+
+NODES_OUTPUT_DIR = [
+    InputStep(),
+    Step(
+        step_name="step_1_for_output_dir_example",
+        input_slots=[
+            InputSlot(
+                name="step_1_main_input",
+                env_var="STEP_1_MAIN_INPUT_FILE_PATHS",
+                validator=validate_input_file_dummy,
+            )
+        ],
+        output_slots=[OutputSlot("step_1_main_output_directory")],
+    ),
+    Step(
+        step_name="step_2_for_output_dir_example",
+        input_slots=[
+            InputSlot(
+                name="step_2_main_input",
+                env_var="DUMMY_CONTAINER_MAIN_INPUT_DIR_PATH",
+                validator=validate_dir,
+            )
+        ],
+        output_slots=[OutputSlot("step_2_main_output")],
+    ),
+    OutputStep(
+        input_slots=[
+            InputSlot(name="result", env_var=None, validator=validate_input_file_dummy)
+        ],
+    ),
+]
+EDGES_OUTPUT_DIR = [
+    EdgeParams(
+        source_node="input_data",
+        target_node="step_1_for_output_dir_example",
+        output_slot="all",
+        input_slot="step_1_main_input",
+    ),
+    EdgeParams(
+        source_node="step_1_for_output_dir_example",
+        target_node="step_2_for_output_dir_example",
+        output_slot="step_1_main_output_directory",
+        input_slot="step_2_main_input",
+    ),
+    EdgeParams(
+        source_node="step_2_for_output_dir_example",
+        target_node="results",
+        output_slot="step_2_main_output",
+        input_slot="result",
+    ),
+]
+SCHEMA_PARAMS_OUTPUT_DIR = (NODES_OUTPUT_DIR, EDGES_OUTPUT_DIR)

--- a/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.def
+++ b/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./dummy_step_1_for_output_dir_example.py /dummy_step_1_for_output_dir_example.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /dummy_step_1_for_output_dir_example.py '$@'

--- a/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.py
+++ b/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.py
@@ -1,0 +1,17 @@
+# PIPELINE_SCHEMA: output_dir
+# STEP_NAME: step_1_for_output_dir_example
+# REQUIREMENTS: pandas==2.1.2 pyarrow
+
+import pandas as pd
+import os
+from pathlib import Path
+
+data = pd.read_parquet(os.environ["STEP_1_MAIN_INPUT_FILE_PATHS"])
+
+print(data)
+
+dir_path = Path(os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"])
+dir_path.mkdir(parents=True, exist_ok=True)
+
+for i in range(3):
+    data.to_parquet(dir_path / f"result_{i}.parquet")

--- a/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.def
+++ b/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./dummy_step_2_for_output_dir_example.py /dummy_step_2_for_output_dir_example.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /dummy_step_2_for_output_dir_example.py '$@'

--- a/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.py
+++ b/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.py
@@ -1,0 +1,21 @@
+# PIPELINE_SCHEMA: output_dir
+# STEP_NAME: step_2_for_output_dir_example
+# REQUIREMENTS: pandas==2.1.2 pyarrow
+
+import pandas as pd
+import shutil
+import os
+from pathlib import Path
+
+dir_path = Path(os.environ["DUMMY_CONTAINER_MAIN_INPUT_DIR_PATH"])
+saved = False
+
+for i, f in enumerate([f for f in dir_path.iterdir() if f.is_file()]):
+    if "snakemake" in str(f):
+        continue
+
+    if not saved:
+        shutil.copy(f, os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"])
+        saved = True
+
+    print(pd.read_parquet(f))

--- a/src/easylink/utilities/validation_utils.py
+++ b/src/easylink/utilities/validation_utils.py
@@ -50,3 +50,9 @@ def validate_input_file_dummy(filepath: str) -> None:
         raise LookupError(
             f"Data file {filepath} is missing required column(s) {missing_columns}"
         )
+
+
+def validate_dir(filepath: str) -> None:
+    input_path = Path(filepath)
+    if not input_path.is_dir():
+        raise NotADirectoryError(f"The path {filepath} is not a directory.")

--- a/tests/integration/test_snakemake.py
+++ b/tests/integration/test_snakemake.py
@@ -33,3 +33,26 @@ def test_missing_results(test_specific_results_dir, mocker, caplog):
         )
     assert exit.value.code == 1
     assert "MissingOutputException" in caplog.text
+
+
+@pytest.mark.slow
+def test_outputting_a_directory(test_specific_results_dir, mocker, caplog):
+    """Test that the pipeline fails when a step is missing output files."""
+    nodes, edges = TESTING_SCHEMA_PARAMS["output_dir"]
+    mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
+    mocker.patch(
+        "easylink.configuration.Config._get_schema",
+        return_value=PipelineSchema("output_dir", nodes=nodes, edges=edges),
+    )
+
+    with pytest.raises(SystemExit) as exit:
+        main(
+            command="run",
+            pipeline_specification=SPECIFICATIONS_DIR
+            / "integration"
+            / "pipeline_output_dir.yaml",
+            input_data=SPECIFICATIONS_DIR / "common/input_data_one_file.yaml",
+            computing_environment=SPECIFICATIONS_DIR / "common/environment_local.yaml",
+            results_dir=test_specific_results_dir,
+        )
+    assert exit.value.code == 0

--- a/tests/specifications/common/input_data_one_file.yaml
+++ b/tests/specifications/common/input_data_one_file.yaml
@@ -1,0 +1,1 @@
+input_file_1: /mnt/team/simulation_science/priv/engineering/er_ecosystem/sample_data/dummy/input_file_1.parquet

--- a/tests/specifications/integration/pipeline_output_dir.yaml
+++ b/tests/specifications/integration/pipeline_output_dir.yaml
@@ -1,0 +1,7 @@
+steps:
+  step_1_for_output_dir_example:
+    implementation:
+      name: dummy_step_1_for_output_dir_example
+  step_2_for_output_dir_example:
+    implementation:
+      name: dummy_step_2_for_output_dir_example


### PR DESCRIPTION
## Add a failing test for an output slot being directory-valued

### Description
- *Category*: test
- *JIRA issue*: None
- *Research reference*: None

### Changes and notes

### Verification and Testing

Test **fails** (`pytest tests/integration/test_snakemake.py::test_outputting_a_directory --runslow`) with:

```
ERROR    snakemake.logging:logging.py:621 ImproperOutputException in rule dummy_step_1_for_output_dir_example in file /mnt/team/simulation_science/priv/engineering/tests/output/tmpcm9pa1f4/Snakefile, line 32:
Outputs of incorrect type (directories when expecting files or vice versa). Output directories must be flagged with directory(). for rule dummy_step_1_for_output_dir_example:
    output: intermediate/dummy_step_1_for_output_dir_example/output_dir
    affected files:
        intermediate/dummy_step_1_for_output_dir_example/output_dir
ERROR    snakemake.logging:logging.py:621 Exiting because a job execution failed. Look above for error message
ERROR    snakemake.logging:logging.py:621 WorkflowError:
At least one job did not complete successfully.
```

I very hackily verified that this test would pass if the snakemake `directory()` function were called in the output of Step 1.