### PR TITLE
Sbachmei/mic 6061/support directories as step intermediates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.17 - 5/14/25**
+
+ - Support directories as step intermediates
+
 **0.1.16 - 5/13/25**
 
  - Implement new cli command to simplify implementation creation

--- a/src/easylink/implementation.py
+++ b/src/easylink/implementation.py
@@ -135,8 +135,17 @@ class Implementation:
 
     @property
     def outputs(self) -> dict[str, list[str]]:
-        """The expected output metadata."""
-        return self._metadata["outputs"]
+        """The expected output paths. If output metadata is provided, use it. Otherwise,
+        assume that the output is a sub-directory with the name of the output slot.
+        If there is only one output slot, use '.'."""
+        if len(self.output_slots) == 1:
+            return self._metadata.get("outputs", {list(self.output_slots.keys())[0]: "."})
+        return {
+            output_slot_name: self._metadata.get("outputs", {}).get(
+                output_slot_name, output_slot_name
+            )
+            for output_slot_name in self.output_slots
+        }
 
 
 class NullImplementation:

--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -192,3 +192,17 @@ step_1a_and_step_1b_combined_python_pandas:
   script_cmd: python /dummy_step.py
   outputs:
     step_1_main_output: result.parquet
+dummy_step_1_for_output_dir_example:
+  steps:
+  - step_1_for_output_dir_example
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/dummy_step_1_for_output_dir_example.sif
+  script_cmd: python /dummy_step_1_for_output_dir_example.py
+  outputs:
+    step_1_main_output_directory: output_dir/
+dummy_step_2_for_output_dir_example:
+  steps:
+  - step_2_for_output_dir_example
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/dummy_step_2_for_output_dir_example.sif
+  script_cmd: python /dummy_step_2_for_output_dir_example.py
+  outputs:
+    step_2_main_output: result.parquet

--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -199,6 +199,14 @@ dummy_step_1_for_output_dir_example:
   script_cmd: python /dummy_step_1_for_output_dir_example.py
   outputs:
     step_1_main_output_directory: output_dir/
+dummy_step_1_for_output_dir_example_default:
+  steps:
+  - step_1_for_output_dir_example
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/dummy_step_1_for_output_dir_example.sif
+  script_cmd: python /dummy_step_1_for_output_dir_example.py
+  # leave outputs out for testing purposes
+  # outputs:
+  #   step_1_main_output_directory: output_dir/
 dummy_step_2_for_output_dir_example:
   steps:
   - step_2_for_output_dir_example

--- a/src/easylink/pipeline_schema_constants/__init__.py
+++ b/src/easylink/pipeline_schema_constants/__init__.py
@@ -17,6 +17,7 @@ ALLOWED_SCHEMA_PARAMS = {
 
 TESTING_SCHEMA_PARAMS = {
     "integration": testing.SCHEMA_PARAMS_ONE_STEP,
+    "output_dir": testing.SCHEMA_PARAMS_OUTPUT_DIR,
     "combine_bad_topology": testing.SCHEMA_PARAMS_BAD_COMBINED_TOPOLOGY,
     "combine_bad_implementation_names": testing.SCHEMA_PARAMS_BAD_COMBINED_TOPOLOGY,
     "nested_templated_steps": testing.SCHEMA_PARAMS_NESTED_TEMPLATED_STEPS,

--- a/src/easylink/pipeline_schema_constants/testing.py
+++ b/src/easylink/pipeline_schema_constants/testing.py
@@ -26,7 +26,7 @@ from easylink.step import (
 )
 from easylink.utilities.aggregator_utils import concatenate_datasets
 from easylink.utilities.splitter_utils import split_data_in_two
-from easylink.utilities.validation_utils import validate_input_file_dummy
+from easylink.utilities.validation_utils import validate_input_file_dummy, validate_dir
 
 NODES_ONE_STEP = [
     InputStep(),
@@ -582,3 +582,55 @@ EDGES_ONE_STEP_TWO_ISLOTS = [
     ),
 ]
 SCHEMA_PARAMS_EP_HIERARCHICAL_STEP = (NODES_EP_HIERARCHICAL_STEP, EDGES_ONE_STEP_TWO_ISLOTS)
+
+NODES_OUTPUT_DIR = [
+    InputStep(),
+    Step(
+        step_name="step_1_for_output_dir_example",
+        input_slots=[
+            InputSlot(
+                name="step_1_main_input",
+                env_var="STEP_1_MAIN_INPUT_FILE_PATHS",
+                validator=validate_input_file_dummy,
+            )
+        ],
+        output_slots=[OutputSlot("step_1_main_output_directory")],
+    ),
+    Step(
+        step_name="step_2_for_output_dir_example",
+        input_slots=[
+            InputSlot(
+                name="step_2_main_input",
+                env_var="DUMMY_CONTAINER_MAIN_INPUT_DIR_PATH",
+                validator=validate_dir,
+            )
+        ],
+        output_slots=[OutputSlot("step_2_main_output")],
+    ),
+    OutputStep(
+        input_slots=[
+            InputSlot(name="result", env_var=None, validator=validate_input_file_dummy)
+        ],
+    ),
+]
+EDGES_OUTPUT_DIR = [
+    EdgeParams(
+        source_node="input_data",
+        target_node="step_1_for_output_dir_example",
+        output_slot="all",
+        input_slot="step_1_main_input",
+    ),
+    EdgeParams(
+        source_node="step_1_for_output_dir_example",
+        target_node="step_2_for_output_dir_example",
+        output_slot="step_1_main_output_directory",
+        input_slot="step_2_main_input",
+    ),
+    EdgeParams(
+        source_node="step_2_for_output_dir_example",
+        target_node="results",
+        output_slot="step_2_main_output",
+        input_slot="result",
+    ),
+]
+SCHEMA_PARAMS_OUTPUT_DIR = (NODES_OUTPUT_DIR, EDGES_OUTPUT_DIR)

--- a/src/easylink/pipeline_schema_constants/testing.py
+++ b/src/easylink/pipeline_schema_constants/testing.py
@@ -26,7 +26,7 @@ from easylink.step import (
 )
 from easylink.utilities.aggregator_utils import concatenate_datasets
 from easylink.utilities.splitter_utils import split_data_in_two
-from easylink.utilities.validation_utils import validate_input_file_dummy, validate_dir
+from easylink.utilities.validation_utils import validate_dir, validate_input_file_dummy
 
 NODES_ONE_STEP = [
     InputStep(),

--- a/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.def
+++ b/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./dummy_step_1_for_output_dir_example.py /dummy_step_1_for_output_dir_example.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /dummy_step_1_for_output_dir_example.py '$@'

--- a/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.py
+++ b/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.py
@@ -1,0 +1,17 @@
+# PIPELINE_SCHEMA: output_dir
+# STEP_NAME: step_1_for_output_dir_example
+# REQUIREMENTS: pandas==2.1.2 pyarrow
+
+import pandas as pd
+import os
+from pathlib import Path
+
+data = pd.read_parquet(os.environ["STEP_1_MAIN_INPUT_FILE_PATHS"])
+
+print(data)
+
+dir_path = Path(os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"])
+dir_path.mkdir(parents=True, exist_ok=True)
+
+for i in range(3):
+    data.to_parquet(dir_path / f"result_{i}.parquet")

--- a/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.py
+++ b/src/easylink/steps/output_dir/dummy_step_1_for_output_dir_example.py
@@ -2,9 +2,10 @@
 # STEP_NAME: step_1_for_output_dir_example
 # REQUIREMENTS: pandas==2.1.2 pyarrow
 
-import pandas as pd
 import os
 from pathlib import Path
+
+import pandas as pd
 
 data = pd.read_parquet(os.environ["STEP_1_MAIN_INPUT_FILE_PATHS"])
 

--- a/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.def
+++ b/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./dummy_step_2_for_output_dir_example.py /dummy_step_2_for_output_dir_example.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /dummy_step_2_for_output_dir_example.py '$@'

--- a/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.py
+++ b/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.py
@@ -2,10 +2,11 @@
 # STEP_NAME: step_2_for_output_dir_example
 # REQUIREMENTS: pandas==2.1.2 pyarrow
 
-import pandas as pd
-import shutil
 import os
+import shutil
 from pathlib import Path
+
+import pandas as pd
 
 dir_path = Path(os.environ["DUMMY_CONTAINER_MAIN_INPUT_DIR_PATH"])
 saved = False

--- a/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.py
+++ b/src/easylink/steps/output_dir/dummy_step_2_for_output_dir_example.py
@@ -1,0 +1,21 @@
+# PIPELINE_SCHEMA: output_dir
+# STEP_NAME: step_2_for_output_dir_example
+# REQUIREMENTS: pandas==2.1.2 pyarrow
+
+import pandas as pd
+import shutil
+import os
+from pathlib import Path
+
+dir_path = Path(os.environ["DUMMY_CONTAINER_MAIN_INPUT_DIR_PATH"])
+saved = False
+
+for i, f in enumerate([f for f in dir_path.iterdir() if f.is_file()]):
+    if "snakemake" in str(f):
+        continue
+
+    if not saved:
+        shutil.copy(f, os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"])
+        saved = True
+
+    print(pd.read_parquet(f))

--- a/src/easylink/utilities/validation_utils.py
+++ b/src/easylink/utilities/validation_utils.py
@@ -50,3 +50,9 @@ def validate_input_file_dummy(filepath: str) -> None:
         raise LookupError(
             f"Data file {filepath} is missing required column(s) {missing_columns}"
         )
+
+
+def validate_dir(filepath: str) -> None:
+    input_path = Path(filepath)
+    if not input_path.is_dir():
+        raise NotADirectoryError(f"The path {filepath} is not a directory.")

--- a/tests/integration/test_snakemake.py
+++ b/tests/integration/test_snakemake.py
@@ -36,7 +36,8 @@ def test_missing_results(test_specific_results_dir, mocker, caplog):
 
 
 @pytest.mark.slow
-def test_outputting_a_directory(test_specific_results_dir, mocker):
+@pytest.mark.parametrize("outputs_specified", [True, False])
+def test_outputting_a_directory(outputs_specified: bool, test_specific_results_dir, mocker):
     """Test that the pipeline fails when a step is missing output files."""
     nodes, edges = TESTING_SCHEMA_PARAMS["output_dir"]
     mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
@@ -45,14 +46,33 @@ def test_outputting_a_directory(test_specific_results_dir, mocker):
         return_value=PipelineSchema("output_dir", nodes=nodes, edges=edges),
     )
 
+    pipeline_yaml_name = (
+        "pipeline_output_dir.yaml"
+        if outputs_specified
+        else "pipeline_output_dir_default.yaml"
+    )
+    step_1_output_subdir = (
+        "dummy_step_1_for_output_dir_example/output_dir"
+        if outputs_specified
+        else "dummy_step_1_for_output_dir_example_default"
+    )
+
     with pytest.raises(SystemExit) as exit:
         main(
             command="run",
-            pipeline_specification=SPECIFICATIONS_DIR
-            / "integration"
-            / "pipeline_output_dir.yaml",
+            pipeline_specification=SPECIFICATIONS_DIR / "integration" / pipeline_yaml_name,
             input_data=SPECIFICATIONS_DIR / "common/input_data_one_file.yaml",
             computing_environment=SPECIFICATIONS_DIR / "common/environment_local.yaml",
             results_dir=test_specific_results_dir,
         )
     assert exit.value.code == 0
+    assert (
+        len(
+            list(
+                (test_specific_results_dir / "intermediate" / step_1_output_subdir).rglob(
+                    "*.parquet"
+                )
+            )
+        )
+        == 3
+    )

--- a/tests/integration/test_snakemake.py
+++ b/tests/integration/test_snakemake.py
@@ -33,3 +33,26 @@ def test_missing_results(test_specific_results_dir, mocker, caplog):
         )
     assert exit.value.code == 1
     assert "MissingOutputException" in caplog.text
+
+
+@pytest.mark.slow
+def test_outputting_a_directory(test_specific_results_dir, mocker, caplog):
+    """Test that the pipeline fails when a step is missing output files."""
+    nodes, edges = TESTING_SCHEMA_PARAMS["output_dir"]
+    mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
+    mocker.patch(
+        "easylink.configuration.Config._get_schema",
+        return_value=PipelineSchema("output_dir", nodes=nodes, edges=edges),
+    )
+
+    with pytest.raises(SystemExit) as exit:
+        main(
+            command="run",
+            pipeline_specification=SPECIFICATIONS_DIR
+            / "integration"
+            / "pipeline_output_dir.yaml",
+            input_data=SPECIFICATIONS_DIR / "common/input_data_one_file.yaml",
+            computing_environment=SPECIFICATIONS_DIR / "common/environment_local.yaml",
+            results_dir=test_specific_results_dir,
+        )
+    assert exit.value.code == 0

--- a/tests/integration/test_snakemake.py
+++ b/tests/integration/test_snakemake.py
@@ -36,7 +36,7 @@ def test_missing_results(test_specific_results_dir, mocker, caplog):
 
 
 @pytest.mark.slow
-def test_outputting_a_directory(test_specific_results_dir, mocker, caplog):
+def test_outputting_a_directory(test_specific_results_dir, mocker):
     """Test that the pipeline fails when a step is missing output files."""
     nodes, edges = TESTING_SCHEMA_PARAMS["output_dir"]
     mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)

--- a/tests/specifications/common/input_data_one_file.yaml
+++ b/tests/specifications/common/input_data_one_file.yaml
@@ -1,0 +1,1 @@
+input_file_1: /mnt/team/simulation_science/priv/engineering/er_ecosystem/sample_data/dummy/input_file_1.parquet

--- a/tests/specifications/integration/pipeline_output_dir.yaml
+++ b/tests/specifications/integration/pipeline_output_dir.yaml
@@ -1,0 +1,7 @@
+steps:
+  step_1_for_output_dir_example:
+    implementation:
+      name: dummy_step_1_for_output_dir_example
+  step_2_for_output_dir_example:
+    implementation:
+      name: dummy_step_2_for_output_dir_example

--- a/tests/specifications/integration/pipeline_output_dir_default.yaml
+++ b/tests/specifications/integration/pipeline_output_dir_default.yaml
@@ -1,0 +1,7 @@
+steps:
+  step_1_for_output_dir_example:
+    implementation:
+      name: dummy_step_1_for_output_dir_example_default
+  step_2_for_output_dir_example:
+    implementation:
+      name: dummy_step_2_for_output_dir_example

--- a/tests/unit/rule_strings/implemented_rule_local.txt
+++ b/tests/unit/rule_strings/implemented_rule_local.txt
@@ -6,12 +6,12 @@ rule:
         dummy_container_main_input_file_paths=['foo'],
         dummy_container_secondary_input_file_paths=['bar'],
         validations=['bar'],
-    output: ['baz']
+    output: ['some/file.txt']
     log: "spam/foo_rule-output.log"
     container: "Multipolarity.sif"
     shell:
         '''
-        export DUMMY_CONTAINER_OUTPUT_PATHS=baz
+        export DUMMY_CONTAINER_OUTPUT_PATHS=some/file.txt
         export DUMMY_CONTAINER_DIAGNOSTICS_DIRECTORY=spam
         export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=foo
         export DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS=bar

--- a/tests/unit/rule_strings/implemented_rule_slurm.txt
+++ b/tests/unit/rule_strings/implemented_rule_slurm.txt
@@ -6,7 +6,7 @@ rule:
         dummy_container_main_input_file_paths=['foo'],
         dummy_container_secondary_input_file_paths=['bar'],
         validations=['bar'],
-    output: ['baz']
+    output: ['some/file.txt']
     log: "spam/foo_rule-output.log"
     container: "Multipolarity.sif"
     resources:
@@ -17,7 +17,7 @@ rule:
         slurm_extra="--output 'spam/foo_rule-slurm-%j.log'"
     shell:
         '''
-        export DUMMY_CONTAINER_OUTPUT_PATHS=baz
+        export DUMMY_CONTAINER_OUTPUT_PATHS=some/file.txt
         export DUMMY_CONTAINER_DIAGNOSTICS_DIRECTORY=spam
         export DUMMY_CONTAINER_MAIN_INPUT_FILE_PATHS=foo
         export DUMMY_CONTAINER_SECONDARY_INPUT_FILE_PATHS=bar

--- a/tests/unit/test_implementation.py
+++ b/tests/unit/test_implementation.py
@@ -1,6 +1,9 @@
 # mypy: ignore-errors
+import pytest
 from layered_config_tree import LayeredConfigTree
+from pytest_mock import MockerFixture
 
+from easylink.graph_components import OutputSlot
 from easylink.implementation import Implementation
 
 
@@ -24,3 +27,66 @@ def test__get_env_vars(mocker):
         "baz": "qux",
         "spam": "eggs",
     }
+
+
+@pytest.mark.parametrize(
+    "output_slots, metadata_outputs, expected_outputs",
+    [
+        # one slot, defined output
+        (
+            ["main_output"],
+            {"main_output": "main/output/filepath"},
+            {"main_output": "main/output/filepath"},
+        ),
+        # one slot, undefined output
+        (["main_output"], None, {"main_output": "."}),
+        # two slots, defined outputs
+        (
+            ["main_output", "secondary_output"],
+            {
+                "main_output": "main/output/filepath",
+                "secondary_output": "secondary/output/filepath",
+            },
+            {
+                "main_output": "main/output/filepath",
+                "secondary_output": "secondary/output/filepath",
+            },
+        ),
+        # two slots, one defined and one undefined output
+        (
+            ["main_output", "secondary_output"],
+            {"secondary_output": "secondary/output/filepath"},
+            {"main_output": "main_output", "secondary_output": "secondary/output/filepath"},
+        ),
+        # two slots, both undefined outputs
+        (
+            ["main_output", "secondary_output"],
+            None,
+            {"main_output": "main_output", "secondary_output": "secondary_output"},
+        ),
+    ],
+)
+def test_outputs(
+    output_slots: list[str],
+    metadata_outputs: dict[str, str],
+    expected_outputs: dict[str, str],
+    mocker: MockerFixture,
+):
+    """Test that the outputs property returns the correct output details."""
+    mocker.patch(
+        "easylink.implementation.Implementation._load_metadata",
+        return_value={
+            "steps": [
+                "this_step",
+            ],
+            "image_path": "/path/to/image.sif",
+            "script_cmd": "python /path/to/script.py",
+            **({"outputs": metadata_outputs} if metadata_outputs else {}),
+        },
+    )
+    implementation = Implementation(
+        schema_steps=["this_step"],
+        implementation_config=LayeredConfigTree({"name": "test"}),
+        output_slots=[OutputSlot(slot) for slot in output_slots],
+    )
+    assert implementation.outputs == expected_outputs


### PR DESCRIPTION
## Support directories as step intermediates
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6061
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This adds support for a step to use a directory as an output rather than discrete
files.

With this, you no longer need to specify an "outputs" key in the
implementation_metadata.yaml if the output is to be a directory:
* if you provide any outputs, it will use them
* if there is only one input slot and you do not provide outputs, it will use the wd
* if there are multiple slots, any that don't have an output specified will use a sub-dir
of that output slot's name

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

* due to cluster impact, I was unable to run the two slow spark tests.
* this passes the new implementation test @zmbc wrote, but I did NOT
test beyond that. I tried simply removing the outputs from the pipeline.yamls
we already test against, but it wasn't that simple.