### PR TITLE
Sbachmei/mic 6054/hide development pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.1.18 - 5/15/25**
+**0.1.18 - 5/14/25**
 
  - Refactor to use a single pipeline schema rather than multiple potential schemas
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.1.18 - 5/15/25**
+
+ - Refactor to use a single pipeline schema rather than multiple potential schemas
+
 **0.1.17 - 5/14/25**
 
  - Support directories as step intermediates

--- a/src/easylink/cli.py
+++ b/src/easylink/cli.py
@@ -91,6 +91,11 @@ SHARED_OPTIONS = [
         default=False,
         help="Do not save the results in a timestamped sub-directory of ``--output-dir``.",
     ),
+    click.option(
+        "--schema",
+        hidden=True,
+        default="main",
+    ),
 ]
 
 VERBOSE_WITH_DEBUGGER_OPTIONS = [
@@ -165,6 +170,7 @@ def run(
     input_data: str,
     output_dir: str | None,
     no_timestamp: bool,
+    schema: str,
     computing_environment: str | None,
     verbose: int,
     with_debugger: bool,
@@ -190,6 +196,7 @@ def run(
         input_data=input_data,
         computing_environment=computing_environment,
         results_dir=results_dir,
+        schema_name=schema,
     )
     logger.info("*** FINISHED ***")
 
@@ -201,6 +208,7 @@ def generate_dag(
     input_data: str,
     output_dir: str | None,
     no_timestamp: bool,
+    schema: str,
     verbose: int,
     with_debugger: bool,
 ) -> None:
@@ -223,6 +231,7 @@ def generate_dag(
         input_data=input_data,
         computing_environment=None,
         results_dir=results_dir,
+        schema_name=schema,
     )
     logger.info("*** DAG saved to result directory ***")
 

--- a/src/easylink/devtools/implementation_creator.py
+++ b/src/easylink/devtools/implementation_creator.py
@@ -315,8 +315,11 @@ class ImplementationCreator:
 
         If no pipeline schema is specified, "main" will be used by default.
         """
-        schema_name = _extract_metadata("PIPELINE_SCHEMA", script_path)
-        return "main" if len(schema_name) == 0 else schema_name[0]
+        schema_name_list: list[str] = _extract_metadata("PIPELINE_SCHEMA", script_path)
+        schema_name = "main" if len(schema_name_list) == 0 else schema_name_list[0]
+        if schema_name not in SCHEMA_PARAMS:
+            raise ValueError(f"Pipeline schema '{schema_name}' is not supported.")
+        return schema_name
 
     @staticmethod
     def _write_metadata(info: dict[str, dict[str, str]]) -> None:

--- a/src/easylink/devtools/implementation_creator.py
+++ b/src/easylink/devtools/implementation_creator.py
@@ -19,7 +19,7 @@ from typing import cast
 import yaml
 from loguru import logger
 
-from easylink.pipeline_schema_constants import ALLOWED_SCHEMA_PARAMS
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.step import (
     ChoiceStep,
     EmbarrassinglyParallelStep,
@@ -244,17 +244,17 @@ class ImplementationCreator:
     @staticmethod
     def _extract_output_slot(script_path: Path, step_name: str) -> str:
         """Extracts the name of the output slot that this script is implementing."""
-        schema = ImplementationCreator._extract_pipeline_schema(script_path)
-        implementable_steps = ImplementationCreator._extract_implementable_steps(schema)
+        schema_name = ImplementationCreator._extract_pipeline_schema_name(script_path)
+        implementable_steps = ImplementationCreator._extract_implementable_steps(schema_name)
         step_names = [step.name for step in implementable_steps]
         if step_name not in step_names:
             raise ValueError(
-                f"'{step_name}' does not exist as an implementable step in the '{schema}' pipeline schema. "
+                f"'{step_name}' does not exist as an implementable step in the '{schema_name}' pipeline schema. "
             )
         duplicates = list(set([step for step in step_names if step_names.count(step) > 1]))
         if duplicates:
             raise ValueError(
-                f"Multiple implementable steps with the same name found in the '{schema}' "
+                f"Multiple implementable steps with the same name found in the '{schema_name}' "
                 f"pipeline schema: {duplicates}."
             )
         implemented_step = [step for step in implementable_steps if step.name == step_name][0]
@@ -266,7 +266,7 @@ class ImplementationCreator:
         return list(implemented_step.output_slots)[0]
 
     @staticmethod
-    def _extract_implementable_steps(schema: str) -> list[Step]:
+    def _extract_implementable_steps(schema_name: str) -> list[Step]:
         """Extracts all implementable steps from the pipeline schema.
 
         This method recursively traverses the pipeline schema specified in the script
@@ -296,8 +296,7 @@ class ImplementationCreator:
                 implementable_steps.append(node)
                 return
 
-        schema_steps = ALLOWED_SCHEMA_PARAMS[schema][0]
-
+        schema_steps, _edges = SCHEMA_PARAMS[schema_name]
         implementable_steps: list[Step] = []
         for schema_step in schema_steps:
             _process_step(schema_step)
@@ -305,7 +304,7 @@ class ImplementationCreator:
         return implementable_steps
 
     @staticmethod
-    def _extract_pipeline_schema(script_path: Path) -> str:
+    def _extract_pipeline_schema_name(script_path: Path) -> str:
         """Extracts the relevant pipeline schema name.
 
         The expectation is that the output slot's name is specified within the script
@@ -316,8 +315,8 @@ class ImplementationCreator:
 
         If no pipeline schema is specified, "main" will be used by default.
         """
-        schema = _extract_metadata("PIPELINE_SCHEMA", script_path)
-        return "main" if len(schema) == 0 else schema[0]
+        schema_name = _extract_metadata("PIPELINE_SCHEMA", script_path)
+        return "main" if len(schema_name) == 0 else schema_name[0]
 
     @staticmethod
     def _write_metadata(info: dict[str, dict[str, str]]) -> None:

--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -204,9 +204,6 @@ dummy_step_1_for_output_dir_example_default:
   - step_1_for_output_dir_example
   image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/dummy_step_1_for_output_dir_example.sif
   script_cmd: python /dummy_step_1_for_output_dir_example.py
-  # leave outputs out for testing purposes
-  # outputs:
-  #   step_1_main_output_directory: output_dir/
 dummy_step_2_for_output_dir_example:
   steps:
   - step_2_for_output_dir_example
@@ -214,3 +211,17 @@ dummy_step_2_for_output_dir_example:
   script_cmd: python /dummy_step_2_for_output_dir_example.py
   outputs:
     step_2_main_output: result.parquet
+step_1_sbachmei:
+  steps:
+  - step_1
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/sbachmei/step_1_sbachmei.sif
+  script_cmd: python /step_1_sbachmei.py
+  outputs:
+    step_1_main_output: result.parquet
+step_4a_sbachmei:
+  steps:
+  - step_4a
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/sbachmei/step_4a_sbachmei.sif
+  script_cmd: python /step_4a_sbachmei.py
+  outputs:
+    step_4a_main_output: result.parquet

--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -211,17 +211,3 @@ dummy_step_2_for_output_dir_example:
   script_cmd: python /dummy_step_2_for_output_dir_example.py
   outputs:
     step_2_main_output: result.parquet
-step_1_sbachmei:
-  steps:
-  - step_1
-  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/sbachmei/step_1_sbachmei.sif
-  script_cmd: python /step_1_sbachmei.py
-  outputs:
-    step_1_main_output: result.parquet
-step_4a_sbachmei:
-  steps:
-  - step_4a
-  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/sbachmei/step_4a_sbachmei.sif
-  script_cmd: python /step_4a_sbachmei.py
-  outputs:
-    step_4a_main_output: result.parquet

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -39,7 +39,7 @@ class PipelineSchema(HierarchicalStep):
 
     Notes
     -----
-    All ``PipelineSchema`` instances are intended to be created by the :meth:`_get_schemas`
+    A ``PipelineSchema`` is intended to be constructed by the :meth:`get_schema`
     class method.
 
     The ``PipelineSchema`` is a high-level abstraction; it represents the desired

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -168,7 +168,7 @@ class PipelineSchema(HierarchicalStep):
         Parameters
         ----------
         name
-            The name of the pipeline schema to get.
+            The name of the ``PipelineSchema`` to get.
 
         Returns
         -------

--- a/src/easylink/pipeline_schema.py
+++ b/src/easylink/pipeline_schema.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from layered_config_tree import LayeredConfigTree
 
 from easylink.graph_components import EdgeParams, ImplementationGraph
-from easylink.pipeline_schema_constants import ALLOWED_SCHEMA_PARAMS
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.step import HierarchicalStep, NonLeafConfigurationState, Step
 
 
@@ -159,22 +159,21 @@ class PipelineSchema(HierarchicalStep):
         )
 
     @classmethod
-    def _get_schemas(cls) -> list["PipelineSchema"]:
+    def get_schema(cls, name: str = "main") -> list["PipelineSchema"]:
         """Gets all allowable ``PipelineSchemas``.
 
         These ``PipelineSchemas`` represent the fully supported pipelines and are
         used to validate the user-requested pipeline.
 
+        Parameters
+        ----------
+        name
+            The name of the pipeline schema to get.
+
         Returns
         -------
-            All allowable ``PipelineSchemas``.
+            The requested ``PipelineSchema``.
         """
-        return [
-            cls(name, nodes=nodes, edges=edges)
-            for name, (nodes, edges) in ALLOWED_SCHEMA_PARAMS.items()
-        ]
-
-
-PIPELINE_SCHEMAS = PipelineSchema._get_schemas()
-"""All allowable :class:`PipelineSchemas<PipelineSchema>` to validate the requested
-pipeline against."""
+        if name not in SCHEMA_PARAMS:
+            raise ValueError(f"Pipeline schema '{name}' is not supported.")
+        return cls(name, *SCHEMA_PARAMS[name])

--- a/src/easylink/pipeline_schema_constants/__init__.py
+++ b/src/easylink/pipeline_schema_constants/__init__.py
@@ -11,11 +11,10 @@ package defines the nodes and edges required to instantiate such ``PipelineSchem
 
 from easylink.pipeline_schema_constants import development, testing
 
-ALLOWED_SCHEMA_PARAMS = {
+SCHEMA_PARAMS = {
+    "the_real_thing": testing.SCHEMA_PARAMS_EP_HIERARCHICAL_STEP,  # REMOVE THIS WHEN FINISHED TESTING
+    # development and testing
     "development": development.SCHEMA_PARAMS,
-}
-
-TESTING_SCHEMA_PARAMS = {
     "integration": testing.SCHEMA_PARAMS_ONE_STEP,
     "output_dir": testing.SCHEMA_PARAMS_OUTPUT_DIR,
     "combine_bad_topology": testing.SCHEMA_PARAMS_BAD_COMBINED_TOPOLOGY,

--- a/src/easylink/pipeline_schema_constants/__init__.py
+++ b/src/easylink/pipeline_schema_constants/__init__.py
@@ -12,7 +12,7 @@ package defines the nodes and edges required to instantiate such ``PipelineSchem
 from easylink.pipeline_schema_constants import development, testing
 
 SCHEMA_PARAMS = {
-    "the_real_thing": testing.SCHEMA_PARAMS_EP_HIERARCHICAL_STEP,  # REMOVE THIS WHEN FINISHED TESTING
+    "main": "TODO",
     # development and testing
     "development": development.SCHEMA_PARAMS,
     "integration": testing.SCHEMA_PARAMS_ONE_STEP,

--- a/src/easylink/runner.py
+++ b/src/easylink/runner.py
@@ -19,7 +19,6 @@ from snakemake.cli import main as snake_main
 
 from easylink.configuration import Config, load_params_from_specification
 from easylink.pipeline import Pipeline
-from easylink.pipeline_schema import PIPELINE_SCHEMAS, PipelineSchema
 from easylink.utilities.data_utils import (
     copy_configuration_files_to_results_directory,
     create_results_directory,
@@ -35,8 +34,8 @@ def main(
     input_data: str | Path,
     computing_environment: str | Path | None,
     results_dir: str | Path,
-    debug=False,
-    potential_schemas: PipelineSchema | list[PipelineSchema] = PIPELINE_SCHEMAS,
+    schema_name: str = "main",
+    debug: bool = False,
 ) -> None:
     """Runs an EasyLink command.
 
@@ -60,17 +59,16 @@ def main(
         to run the pipeline on. If None, the pipeline will be run locally.
     results_dir
         The directory to write results and incidental files (logs, etc.) to.
+    schema_name
+        The name of the schema to validate the pipeline configuration against.
     debug
         If False (the default), will suppress some of the workflow output. This
         is intended to only be used for testing and development purposes.
-    potential_schemas
-        A list of potential schemas to validate the pipeline configuration against.
-        This is primarily used for testing purposes. Defaults to the supported schemas.
     """
     config_params = load_params_from_specification(
         pipeline_specification, input_data, computing_environment, results_dir
     )
-    config = Config(config_params, potential_schemas)
+    config = Config(config_params, schema_name)
     pipeline = Pipeline(config)
     # After validation is completed, create the results directory
     create_results_directory(Path(results_dir))

--- a/tests/e2e/test_easylink_run.py
+++ b/tests/e2e/test_easylink_run.py
@@ -63,7 +63,8 @@ def test_easylink_run(
             f"-i {SPECIFICATIONS_DIR / input_data} "
             f"-e {SPECIFICATIONS_DIR / computing_environment} "
             f"-o {str(test_specific_results_dir)} "
-            "--no-timestamp"
+            "--no-timestamp "
+            "--schema development "
         )
         subprocess.run(
             cmd,

--- a/tests/e2e/test_step_types.py
+++ b/tests/e2e/test_step_types.py
@@ -57,7 +57,8 @@ def test_step_types(
             f"-i {SPECIFICATIONS_DIR / input_data} "
             f"-e {SPECIFICATIONS_DIR / computing_environment} "
             f"-o {str(test_specific_results_dir)} "
-            "--no-timestamp"
+            "--no-timestamp "
+            "--schema development "
         )
         subprocess.run(
             cmd,

--- a/tests/integration/test_compositions.py
+++ b/tests/integration/test_compositions.py
@@ -6,7 +6,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from easylink.pipeline_schema import PipelineSchema
-from easylink.pipeline_schema_constants import TESTING_SCHEMA_PARAMS
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.runner import main
 from easylink.utilities.data_utils import load_yaml
 from tests.conftest import SPECIFICATIONS_DIR
@@ -20,11 +20,8 @@ def test_looping_embarrassingly_parallel_step(test_specific_results_dir: Path) -
     pipeline_specification = EP_SPECIFICATIONS_DIR / "pipeline_loop_step.yaml"
     input_data = COMMON_SPECIFICATIONS_DIR / "input_data.yaml"
 
-    # Load the schema to test against
-    schema = PipelineSchema("looping_ep_step", *TESTING_SCHEMA_PARAMS["looping_ep_step"])
-
     _run_pipeline_and_confirm_finished(
-        schema, test_specific_results_dir, pipeline_specification, input_data
+        "looping_ep_step", test_specific_results_dir, pipeline_specification, input_data
     )
 
     intermediate_results_dir = test_specific_results_dir / "intermediate"
@@ -137,11 +134,8 @@ def test_embarrassingly_parallel_sections(
     pipeline_specification = EP_SPECIFICATIONS_DIR / pipeline_spec
     input_data = COMMON_SPECIFICATIONS_DIR / "input_data.yaml"
 
-    # Load the schema to test against
-    schema = PipelineSchema(schema_name, *TESTING_SCHEMA_PARAMS[schema_name])
-
     _run_pipeline_and_confirm_finished(
-        schema, test_specific_results_dir, pipeline_specification, input_data
+        schema_name, test_specific_results_dir, pipeline_specification, input_data
     )
 
     intermediate_results_dir = test_specific_results_dir / "intermediate"
@@ -185,7 +179,7 @@ def test_embarrassingly_parallel_sections(
 
 
 def _run_pipeline_and_confirm_finished(
-    schema: PipelineSchema,
+    schema_name: str,
     results_dir: Path,
     pipeline_specification: Path,
     input_data: Path,
@@ -199,7 +193,7 @@ def _run_pipeline_and_confirm_finished(
             input_data=input_data,
             computing_environment=computing_environment,
             results_dir=results_dir,
-            potential_schemas=schema,
+            schema_name=schema_name,
         )
     assert pytest_wrapped_e.value.code == 0
 

--- a/tests/integration/test_snakemake.py
+++ b/tests/integration/test_snakemake.py
@@ -2,7 +2,7 @@
 import pytest
 
 from easylink.pipeline_schema import PipelineSchema
-from easylink.pipeline_schema_constants import TESTING_SCHEMA_PARAMS
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.runner import main
 from tests.conftest import SPECIFICATIONS_DIR
 
@@ -10,8 +10,7 @@ from tests.conftest import SPECIFICATIONS_DIR
 @pytest.mark.slow
 def test_missing_results(test_specific_results_dir, mocker, caplog):
     """Test that the pipeline fails when a step is missing output files."""
-    nodes, edges = TESTING_SCHEMA_PARAMS["integration"]
-    mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
+    nodes, edges = SCHEMA_PARAMS["integration"]
     mocker.patch(
         "easylink.configuration.Config._get_schema",
         return_value=PipelineSchema("integration", nodes=nodes, edges=edges),
@@ -39,8 +38,7 @@ def test_missing_results(test_specific_results_dir, mocker, caplog):
 @pytest.mark.parametrize("outputs_specified", [True, False])
 def test_outputting_a_directory(outputs_specified: bool, test_specific_results_dir, mocker):
     """Test that the pipeline fails when a step is missing output files."""
-    nodes, edges = TESTING_SCHEMA_PARAMS["output_dir"]
-    mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
+    nodes, edges = SCHEMA_PARAMS["output_dir"]
     mocker.patch(
         "easylink.configuration.Config._get_schema",
         return_value=PipelineSchema("output_dir", nodes=nodes, edges=edges),

--- a/tests/integration/test_snakemake_slurm.py
+++ b/tests/integration/test_snakemake_slurm.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from easylink.pipeline_schema import PipelineSchema
-from easylink.pipeline_schema_constants import TESTING_SCHEMA_PARAMS
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.runner import main
 from easylink.utilities.general_utils import is_on_slurm
 from tests.conftest import SPECIFICATIONS_DIR
@@ -21,8 +21,7 @@ def test_slurm(
     test_specific_results_dir: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that the pipeline runs on SLURM with appropriate resources."""
-    nodes, edges = TESTING_SCHEMA_PARAMS["integration"]
-    mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
+    nodes, edges = SCHEMA_PARAMS["integration"]
     mocker.patch(
         "easylink.configuration.Config._get_schema",
         return_value=PipelineSchema("integration", nodes=nodes, edges=edges),

--- a/tests/integration/test_snakemake_spark.py
+++ b/tests/integration/test_snakemake_spark.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from easylink.pipeline_schema import PipelineSchema
-from easylink.pipeline_schema_constants import TESTING_SCHEMA_PARAMS
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.runner import main
 from easylink.utilities.general_utils import is_on_slurm
 from tests.conftest import SPECIFICATIONS_DIR
@@ -19,8 +19,7 @@ from tests.conftest import SPECIFICATIONS_DIR
 )
 def test_spark_slurm(test_specific_results_dir, mocker, caplog):
     """Test that the pipeline runs spark on SLURM with appropriate resources."""
-    nodes, edges = TESTING_SCHEMA_PARAMS["integration"]
-    mocker.patch("easylink.pipeline_schema.ALLOWED_SCHEMA_PARAMS", TESTING_SCHEMA_PARAMS)
+    nodes, edges = SCHEMA_PARAMS["integration"]
     mocker.patch(
         "easylink.configuration.Config._get_schema",
         return_value=PipelineSchema("integration", nodes=nodes, edges=edges),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -155,4 +155,4 @@ def default_config_params(default_config_paths) -> dict[str, Path]:
 @pytest.fixture()
 def default_config(default_config_params) -> Config:
     """A good/known Config object"""
-    return Config(default_config_params)
+    return Config(default_config_params, schema_name="development")

--- a/tests/unit/test_implementation_creator.py
+++ b/tests/unit/test_implementation_creator.py
@@ -30,7 +30,6 @@ MULTIPLE_METADATA = """
 # STEP_NAME: step_1
 # REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml"""
 
-
 MULTIPLE_STEPS_METADATA = """
 # STEP_NAME: step_1, step_2
 # REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml"""
@@ -96,6 +95,15 @@ def test__extract_pipeline_schema_name(
     with open(script_path, "w") as file:
         file.write(script_content)
     assert ImplementationCreator._extract_pipeline_schema_name(script_path) == expected
+
+
+def test__extract_pipeline_schema_name_raises(tmp_path: Path) -> None:
+    script_path = tmp_path / "foo_step.py"
+    metadata_str = GOOD_METADATA.replace("development", "some-non-existing-schema")
+    with open(script_path, "w") as file:
+        file.write(metadata_str)
+    with pytest.raises(ValueError, match="is not supported"):
+        ImplementationCreator._extract_pipeline_schema_name(script_path)
 
 
 def test__extract_implementable_steps(tmp_path: Path) -> None:

--- a/tests/unit/test_implementation_creator.py
+++ b/tests/unit/test_implementation_creator.py
@@ -89,11 +89,13 @@ def test__extract_requirements_raises(tmp_path: Path) -> None:
         (MISSING_METADATA, "main"),
     ],
 )
-def test__extract_pipeline_schema(script_content: str, expected: str, tmp_path: Path) -> None:
+def test__extract_pipeline_schema_name(
+    script_content: str, expected: str, tmp_path: Path
+) -> None:
     script_path = tmp_path / "foo_step.py"
     with open(script_path, "w") as file:
         file.write(script_content)
-    assert ImplementationCreator._extract_pipeline_schema(script_path) == expected
+    assert ImplementationCreator._extract_pipeline_schema_name(script_path) == expected
 
 
 def test__extract_implementable_steps(tmp_path: Path) -> None:

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -27,7 +27,7 @@ def test_build_snakefile(
         config_paths["computing_environment"] = f"{test_dir}/spark_environment.yaml"
 
     config_params = load_params_from_specification(**config_paths)
-    config = Config(config_params)
+    config = Config(config_params, "development")
     mocker.patch("easylink.implementation.Implementation.validate", return_value={})
     pipeline = Pipeline(config)
     create_results_directory(results_dir)

--- a/tests/unit/test_pipeline_schema.py
+++ b/tests/unit/test_pipeline_schema.py
@@ -4,8 +4,8 @@ from re import match
 import networkx as nx
 
 from easylink.graph_components import InputSlot, OutputSlot
-from easylink.pipeline_schema import PIPELINE_SCHEMAS, PipelineSchema
-from easylink.pipeline_schema_constants import ALLOWED_SCHEMA_PARAMS
+from easylink.pipeline_schema import PipelineSchema
+from easylink.pipeline_schema_constants import SCHEMA_PARAMS
 from easylink.step import Step
 from easylink.utilities.aggregator_utils import concatenate_datasets
 from easylink.utilities.splitter_utils import split_data_by_size
@@ -13,7 +13,7 @@ from easylink.utilities.validation_utils import validate_input_file_dummy
 
 
 def test_schema_instantiation() -> None:
-    nodes, edges = ALLOWED_SCHEMA_PARAMS["development"]
+    nodes, edges = SCHEMA_PARAMS["development"]
     schema = PipelineSchema("development", nodes=nodes, edges=edges)
     sorted_graph = nx.topological_sort(schema.step_graph)
     """Test that the schema is correctly loaded from the pipeline.yaml"""
@@ -26,28 +26,24 @@ def test_schema_instantiation() -> None:
         "results",
     ]
     step_types = [node["step"] for node in sorted_graph]
-    expected_step_types = [type(step) for step in ALLOWED_SCHEMA_PARAMS["development"]]
+    expected_step_types = [type(step) for step in SCHEMA_PARAMS["development"]]
     for step_type, expected_step_types in zip(step_types, expected_step_types):
         assert isinstance(step_type, expected_step_types)
 
 
-def test_get_schemas() -> None:
-    supported_schemas = PIPELINE_SCHEMAS
-    assert isinstance(supported_schemas, list)
-    # Ensure list is populated
-    assert supported_schemas
-    # Check basic structure
-    for schema in supported_schemas:
-        assert schema.name
-        assert schema.step_graph.steps
-        assert isinstance(schema.step_graph.steps, list)
-        for step in schema.step_graph.steps:
-            assert isinstance(step, Step)
-            assert step.name
+def test_get_schema() -> None:
+    schema = PipelineSchema.get_schema("development")
+    assert isinstance(schema, PipelineSchema)
+    assert schema.name
+    assert schema.step_graph.steps
+    assert isinstance(schema.step_graph.steps, list)
+    for step in schema.step_graph.steps:
+        assert isinstance(step, Step)
+        assert step.name
 
 
 def test_validate_input(test_dir: str) -> None:
-    nodes, edges = ALLOWED_SCHEMA_PARAMS["development"]
+    nodes, edges = SCHEMA_PARAMS["development"]
     schema = PipelineSchema("development", nodes=nodes, edges=edges)
     input_data = {"file1": Path(test_dir) / "input_data1/file1.csv"}
     errors = schema.validate_inputs(input_data)
@@ -63,7 +59,7 @@ def test_validate_input(test_dir: str) -> None:
 
 
 def test_pipeline_schema_get_implementation_graph(default_config) -> None:
-    nodes, edges = ALLOWED_SCHEMA_PARAMS["development"]
+    nodes, edges = SCHEMA_PARAMS["development"]
     schema = PipelineSchema("development", nodes=nodes, edges=edges)
     schema.configure_pipeline(default_config.pipeline, default_config.input_data)
     implementation_graph = schema.get_implementation_graph()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -23,7 +23,7 @@ def test_get_singularity_args(default_config, test_dir):
 
 
 def test_get_environment_args_local(default_config_params):
-    config = Config(default_config_params)
+    config = Config(default_config_params, "development")
     assert _get_environment_args(config) == []
 
 
@@ -36,7 +36,7 @@ def test_get_environment_args_slurm(default_config_params, unit_test_specificati
     slurm_config_params["environment"] = load_yaml(
         f"{unit_test_specifications_dir}/environment_spark_slurm.yaml"
     )
-    slurm_config = Config(slurm_config_params)
+    slurm_config = Config(slurm_config_params, "development")
     resources = slurm_config.slurm_resources
     assert _get_environment_args(slurm_config) == [
         "--executor",

--- a/tests/unit/test_validations.py
+++ b/tests/unit/test_validations.py
@@ -213,7 +213,7 @@ def test_pipeline_validation(
     )
 
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     _check_expected_validation_exit(
         error=e,
@@ -229,7 +229,7 @@ def test_out_of_order_steps(default_config_params, unit_test_specifications_dir)
     config_params["pipeline"] = load_yaml(
         f"{unit_test_specifications_dir}/pipeline_out_of_order.yaml"
     )
-    Config(config_params)
+    Config(config_params, "development")
 
 
 def test_unsupported_step(
@@ -243,7 +243,7 @@ def test_unsupported_step(
     )
 
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     _check_expected_validation_exit(
         error=e,
@@ -270,7 +270,7 @@ def test_unsupported_implementation(
     )
 
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     implementation_metadata = load_yaml(paths.IMPLEMENTATION_METADATA)
     supported_implementations = (
@@ -297,7 +297,7 @@ def test_pipeline_schema_bad_input_data_type(default_config_paths, test_dir, cap
     config_params = load_params_from_specification(**config_paths)
     config_params["input_data"] = {}
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     _check_expected_validation_exit(
         error=e,
@@ -314,7 +314,7 @@ def test_pipeline_schema_bad_input_data_type(default_config_paths, test_dir, cap
     )
     config_params = load_params_from_specification(**config_paths)
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     _check_expected_validation_exit(
         error=e,
@@ -338,7 +338,7 @@ def test_pipeline_schema_bad_input_data(default_config_paths, test_dir, caplog):
     )
     config_params = load_params_from_specification(**config_paths)
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     _check_expected_validation_exit(
         error=e,
@@ -359,7 +359,7 @@ def test_pipeline_schema_missing_input_file(default_config_paths, test_dir, capl
     )
     config_params = load_params_from_specification(**config_paths)
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
 
     _check_expected_validation_exit(
         error=e,
@@ -378,7 +378,7 @@ def test_unsupported_container_engine(default_config_params, caplog):
     config_params = default_config_params
     config_params["environment"] = {"container_engine": "foo"}
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
     _check_expected_validation_exit(
         error=e,
         caplog=caplog,
@@ -395,7 +395,7 @@ def test_missing_slurm_details(default_config_params, caplog):
     config_params = default_config_params
     config_params["environment"] = {"computing_environment": "slurm"}
     with pytest.raises(SystemExit) as e:
-        Config(config_params)
+        Config(config_params, "development")
     _check_expected_validation_exit(
         error=e,
         caplog=caplog,


### PR DESCRIPTION
## Support only one schema at a time 

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6054
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> The goal here is ultimately to (1) "hide" the development pipeline schema from
end users and (2) make tests work with the new "main" pipeline schema.

This PR does this by forcing easylink to now work on one pipeline schema
at a time. Previously, it would try and validate a pipeline against any number
of pipeline schems in an ALLOWED_SCHEMA_PARAMS dict and return
the first that validated. The result of this when adding the "main" schema to
that dict was that if a user provided a malformed pipeline.yaml, easylink would
batch log errors pertaining to both the main schema and the development schem.

Now, when running easylink from the command line, you can pass in a `--schema`
option (hidden from help menu and defaults to "main") and easylink only validates
the pipeline.yaml against that.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

