### PR TITLE
Add updating clusters and canonicalizing dummy implementations

### DIFF
--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -220,3 +220,17 @@ dummy_links_to_clusters:
   script_cmd: python /dummy_links_to_clusters.py
   outputs:
     clusters: result.parquet
+dummy_updating_clusters:
+  steps:
+  - updating_clusters
+  image_path: /mnt/share/homes/tylerdy/easylink/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.sif
+  script_cmd: python /dummy_updating_clusters.py
+  outputs:
+    clusters: result.parquet
+dummy_canonicalizing_and_downstream_analysis:
+  steps:
+  - canonicalizing_and_downstream_analysis
+  image_path: /mnt/share/homes/tylerdy/easylink/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.sif
+  script_cmd: python /dummy_canonicalizing_and_downstream_analysis.py
+  outputs:
+    analysis_output: result.parquet

--- a/src/easylink/pipeline_schema_constants/main.py
+++ b/src/easylink/pipeline_schema_constants/main.py
@@ -434,7 +434,7 @@ NODES = [
             ),
             InputSlot(
                 name="clusters",
-                env_var="CLUSTERS_FILE_PATHS",
+                env_var="CLUSTERS_FILE_PATH",
                 validator=validate_clusters,
             ),
         ],

--- a/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.def
+++ b/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./dummy_canonicalizing_and_downstream_analysis.py /dummy_canonicalizing_and_downstream_analysis.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow pyyaml
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /dummy_canonicalizing_and_downstream_analysis.py '$@'

--- a/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.py
+++ b/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from itertools import combinations, chain
+from itertools import chain, combinations
 
 import pandas as pd
 

--- a/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.py
+++ b/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.py
@@ -34,7 +34,9 @@ clusters_path = os.environ["CLUSTERS_FILE_PATH"]
 # DUMMY_CONTAINER_OUTPUT_PATHS is a path to a single directory
 results_dir = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
 
+clusters_df = load_file(clusters_path)
+
 
 output_path = f"{results_dir}{os.path.basename(clusters_path)}.parquet"
 logging.info(f"Writing output for dataset from input {clusters_path} to {output_path}")
-clusters_path.to_parquet(output_path)
+clusters_df.to_parquet(output_path)

--- a/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.py
+++ b/src/easylink/steps/rl-dummy/canonicalizing_and_downstream_analysis/dummy_canonicalizing_and_downstream_analysis.py
@@ -1,0 +1,40 @@
+# STEP_NAME: canonicalizing_and_downstream_analysis
+
+# REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml
+
+# PIPELINE_SCHEMA: main
+
+import logging
+import os
+from itertools import combinations, chain
+
+import pandas as pd
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+
+def load_file(file_path, file_format=None):
+    if file_format is None:
+        file_format = file_path.split(".")[-1]
+    if file_format == "parquet":
+        return pd.read_parquet(file_path)
+    raise ValueError()
+
+
+# LOAD INPUTS and SAVE OUTPUTS
+
+# For dummy we will load the clusters and output them as-is
+
+# CLUSTERS_FILE_PATH is a path to a single file
+clusters_path = os.environ["CLUSTERS_FILE_PATH"]
+# DUMMY_CONTAINER_OUTPUT_PATHS is a path to a single directory
+results_dir = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
+
+
+output_path = f"{results_dir}{os.path.basename(clusters_path)}.parquet"
+logging.info(f"Writing output for dataset from input {clusters_path} to {output_path}")
+clusters_path.to_parquet(output_path)

--- a/src/easylink/steps/rl-dummy/clusters_to_links/dummy_clusters_to_links.py
+++ b/src/easylink/steps/rl-dummy/clusters_to_links/dummy_clusters_to_links.py
@@ -43,9 +43,11 @@ def clusters_to_links(clusters_df):
 
 # LOAD INPUTS and SAVE OUTPUTS
 
-# KNOWN_CLUSTERS_FILE_PATHS is a list of filepaths with one known_clusters.parquet
-# filepath, that may include input data filepaths due to workaround
-clusters_filepaths = os.environ["KNOWN_CLUSTERS_FILE_PATHS"].split(",")
+# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of filepaths with one 
+# known_clusters.parquet filepath, that may include input data filepaths due to workaround
+clusters_filepaths = os.environ[
+    "KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"
+].split(",")
 clusters_filepath = ""
 for path in clusters_filepaths:
     if "known_clusters.parquet" in path:

--- a/src/easylink/steps/rl-dummy/clusters_to_links/dummy_clusters_to_links.py
+++ b/src/easylink/steps/rl-dummy/clusters_to_links/dummy_clusters_to_links.py
@@ -43,11 +43,11 @@ def clusters_to_links(clusters_df):
 
 # LOAD INPUTS and SAVE OUTPUTS
 
-# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of filepaths with one 
+# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of filepaths with one
 # known_clusters.parquet filepath, that may include input data filepaths due to workaround
-clusters_filepaths = os.environ[
-    "KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"
-].split(",")
+clusters_filepaths = os.environ["KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"].split(
+    ","
+)
 clusters_filepath = ""
 for path in clusters_filepaths:
     if "known_clusters.parquet" in path:
@@ -62,7 +62,5 @@ results_dir = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
 clusters_df = load_file(clusters_filepath)
 links_df = clusters_to_links(clusters_df)
 output_path = f"{results_dir}{os.path.basename(clusters_filepath)}.parquet"
-logging.info(
-    f"Writing output for dataset from input {clusters_filepath} to {output_path}"
-)
+logging.info(f"Writing output for dataset from input {clusters_filepath} to {output_path}")
 links_df.to_parquet(output_path)

--- a/src/easylink/steps/rl-dummy/determining_exclusions/dummy_determining_exclusions.py
+++ b/src/easylink/steps/rl-dummy/determining_exclusions/dummy_determining_exclusions.py
@@ -17,11 +17,9 @@ logging.basicConfig(
 
 # LOAD INPUTS
 
-# INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS is list of filepaths which includes 
+# INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS is list of filepaths which includes
 # the known_clusters filepath due to workaround
-dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(
-    ","
-)
+dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(",")
 dataset_paths = [path for path in dataset_paths if "known_clusters.parquet" not in path]
 
 # for workaround, choose path based on INPUT_DATASETS_SPLITTER_CHOICE configuration

--- a/src/easylink/steps/rl-dummy/links_to_clusters/dummy_links_to_clusters.py
+++ b/src/easylink/steps/rl-dummy/links_to_clusters/dummy_links_to_clusters.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from itertools import combinations, chain
+from itertools import chain, combinations
 
 import pandas as pd
 

--- a/src/easylink/steps/rl-dummy/links_to_clusters/dummy_links_to_clusters.py
+++ b/src/easylink/steps/rl-dummy/links_to_clusters/dummy_links_to_clusters.py
@@ -53,4 +53,4 @@ for root, dirs, files in os.walk(links_dir):
         logging.info(
             f"Writing output for dataset from input {links_filepath} to {output_path}"
         )
-        clusters_df.to_parquet(output_path) 
+        clusters_df.to_parquet(output_path)

--- a/src/easylink/steps/rl-dummy/removing_records/dummy_removing_records.py
+++ b/src/easylink/steps/rl-dummy/removing_records/dummy_removing_records.py
@@ -26,9 +26,11 @@ def load_file(file_path, file_format=None):
 
 # LOAD INPUTS and SAVE OUTPUTS
 
-# INPUT_DATASETS_FILE_PATHS is list of filepaths which includes the known_clusters
-# filepath due to workaround
-dataset_paths = os.environ["INPUT_DATASETS_FILE_PATHS"].split(",")
+# INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS is list of filepaths which includes
+# the known_clusters filepath due to workaround
+dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(
+    ","
+)
 dataset_paths = [path for path in dataset_paths if "known_clusters.parquet" not in path]
 
 # for workaround, choose path based on INPUT_DATASETS_SPLITTER_CHOICE configuration

--- a/src/easylink/steps/rl-dummy/removing_records/dummy_removing_records.py
+++ b/src/easylink/steps/rl-dummy/removing_records/dummy_removing_records.py
@@ -28,9 +28,7 @@ def load_file(file_path, file_format=None):
 
 # INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS is list of filepaths which includes
 # the known_clusters filepath due to workaround
-dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(
-    ","
-)
+dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(",")
 dataset_paths = [path for path in dataset_paths if "known_clusters.parquet" not in path]
 
 # for workaround, choose path based on INPUT_DATASETS_SPLITTER_CHOICE configuration

--- a/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.def
+++ b/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./dummy_updating_clusters.py /dummy_updating_clusters.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow pyyaml
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /dummy_updating_clusters.py '$@'

--- a/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.py
+++ b/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.py
@@ -33,9 +33,11 @@ new_clusters_filepath = os.environ["NEW_CLUSTERS_FILE_PATH"]
 # DUMMY_CONTAINER_OUTPUT_PATHS is a path to a single directory
 results_dir = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
 
+clusters_df = load_file(new_clusters_filepath)
+
 
 output_path = f"{results_dir}{os.path.basename(new_clusters_filepath)}.parquet"
 logging.info(
     f"Writing output for dataset from input {new_clusters_filepath} to {output_path}"
 )
-new_clusters_filepath.to_parquet(output_path)
+clusters_df(output_path)

--- a/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.py
+++ b/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.py
@@ -26,26 +26,16 @@ def load_file(file_path, file_format=None):
 
 # LOAD INPUTS and SAVE OUTPUTS
 
+# for dummy we will load only the new clusters and save them as-is
+
 # NEW_CLUSTERS_FILE_PATH is a path to a single file
-links_dir = os.environ["NEW_CLUSTERS_FILE_PATH"]
-# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of filepaths with one
-# known_clusters.parquet filepath, that may include input data filepaths due to workaround
-clusters_filepaths = os.environ[
-    "KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"
-].split(",")
-clusters_filepath = ""
-for path in clusters_filepaths:
-    if "known_clusters.parquet" in path:
-        clusters_filepath = path
-        break
-if clusters_filepath == "":
-    raise ValueError()
+new_clusters_filepath = os.environ["NEW_CLUSTERS_FILE_PATH"]
 # DUMMY_CONTAINER_OUTPUT_PATHS is a path to a single directory
 results_dir = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
 
 
-output_path = f"{results_dir}{os.path.basename(clusters_filepath)}.parquet"
+output_path = f"{results_dir}{os.path.basename(new_clusters_filepath)}.parquet"
 logging.info(
-    f"Writing output for dataset from input {clusters_filepath} to {output_path}"
+    f"Writing output for dataset from input {new_clusters_filepath} to {output_path}"
 )
-clusters_filepath.to_parquet(output_path)
+new_clusters_filepath.to_parquet(output_path)

--- a/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.py
+++ b/src/easylink/steps/rl-dummy/updating_clusters/dummy_updating_clusters.py
@@ -1,0 +1,51 @@
+# STEP_NAME: updating_clusters
+
+# REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml
+
+# PIPELINE_SCHEMA: main
+
+import logging
+import os
+
+import pandas as pd
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+
+def load_file(file_path, file_format=None):
+    if file_format is None:
+        file_format = file_path.split(".")[-1]
+    if file_format == "parquet":
+        return pd.read_parquet(file_path)
+    raise ValueError()
+
+
+# LOAD INPUTS and SAVE OUTPUTS
+
+# NEW_CLUSTERS_FILE_PATH is a path to a single file
+links_dir = os.environ["NEW_CLUSTERS_FILE_PATH"]
+# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of filepaths with one
+# known_clusters.parquet filepath, that may include input data filepaths due to workaround
+clusters_filepaths = os.environ[
+    "KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"
+].split(",")
+clusters_filepath = ""
+for path in clusters_filepaths:
+    if "known_clusters.parquet" in path:
+        clusters_filepath = path
+        break
+if clusters_filepath == "":
+    raise ValueError()
+# DUMMY_CONTAINER_OUTPUT_PATHS is a path to a single directory
+results_dir = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
+
+
+output_path = f"{results_dir}{os.path.basename(clusters_filepath)}.parquet"
+logging.info(
+    f"Writing output for dataset from input {clusters_filepath} to {output_path}"
+)
+clusters_filepath.to_parquet(output_path)


### PR DESCRIPTION
## Add updating clusters and canonicalizing dummy implementations
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/SSCI-2270
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-Change env var for `canonicalizing_and_downstream_analysis` step: 
`CLUSTERS_FILE_PATHS` -> `CLUSTERS_FILE_PATH`
-Add last two implementations that don't currently have a dummy or Splink
implementation - updating_clusters and 
canonicalizing_and_downstream_analysis, both of which just pass inputs 
to outputs

### Verification and Testing
Have not tested the python code, will test all dummy implementations at 
once, but created containers for both.
