### PR TITLE
Add implementations for cascading

### DIFF
--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -295,3 +295,24 @@ fastLink_links_to_clusters:
   script_cmd: Rscript /fastLink_links_to_clusters.R
   outputs:
     clusters: result.parquet
+exclude_clustered:
+  steps:
+  - determining_exclusions
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/exclude_clustered.sif
+  script_cmd: python /exclude_clustered.py
+  outputs:
+    ids_to_remove: result.parquet
+exclude_none:
+  steps:
+  - determining_exclusions
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/exclude_none.sif
+  script_cmd: python /exclude_none.py
+  outputs:
+    ids_to_remove: result.parquet
+update_clusters_by_connected_components:
+  steps:
+  - updating_clusters
+  image_path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/zmbc/update_clusters_by_connected_components.sif
+  script_cmd: python /update_clusters_by_connected_components.py
+  outputs:
+    clusters: result.parquet

--- a/src/easylink/steps/cascading/exclude_clustered.def
+++ b/src/easylink/steps/cascading/exclude_clustered.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./exclude_clustered.py /exclude_clustered.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow pyyaml
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /exclude_clustered.py '$@'

--- a/src/easylink/steps/cascading/exclude_clustered.py
+++ b/src/easylink/steps/cascading/exclude_clustered.py
@@ -1,0 +1,76 @@
+# STEP_NAME: determining_exclusions
+
+# REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml
+
+# PIPELINE_SCHEMA: main
+
+import logging
+import os
+from pathlib import Path
+
+import pandas as pd
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+
+def load_file(file_path, file_format=None):
+    logging.info(f"Loading file {file_path} with format {file_format}")
+    if file_format is None:
+        file_format = file_path.split(".")[-1]
+    if file_format == "parquet":
+        return pd.read_parquet(file_path)
+    raise ValueError(f"Unknown file format {file_format}")
+
+
+# LOAD INPUTS
+
+# INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS is list of filepaths which includes
+# the known_clusters filepath due to workaround
+dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(",")
+dataset_paths = [path for path in dataset_paths if "clusters" not in Path(path).stem]
+
+# for workaround, choose path based on INPUT_DATASET configuration
+splitter_choice = os.environ["INPUT_DATASET"]
+dataset_path = None
+for path in dataset_paths:
+    if splitter_choice == Path(path).stem:
+        dataset_path = path
+        break
+if dataset_path is None:
+    raise ValueError(f"No dataset matching {splitter_choice} found")
+
+# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of file paths.
+# There is one item in it that is a file with "clusters" in the filename.
+# That's the only item we're interested in here.
+# The other items may be there if this is coming from the user's input,
+# due to our workaround for only having one slot of user input.
+clusters_filepaths = [
+    path
+    for path in os.environ["KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"].split(",")
+    if "clusters" in Path(path).stem
+]
+if len(clusters_filepaths) > 1:
+    raise ValueError("Multiple known clusters files found")
+if len(clusters_filepaths) == 0:
+    raise ValueError("No known clusters file found")
+
+clusters_filepath = clusters_filepaths[0]
+
+# Exclude records that have been clustered
+clusters_df = load_file(clusters_filepath)
+dataset_df = load_file(dataset_path)
+clustered_record_ids = set(dataset_df["Record ID"].unique()) & set(clusters_df["Input Record ID"].unique())
+
+IDS_TO_REMOVE = pd.DataFrame({
+    "Record ID": list(clustered_record_ids)
+})
+
+# DUMMY_CONTAINER_OUTPUT_PATHS is a single path to a file (results.parquet)
+results_filepath = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
+
+logging.info(f"Writing output for dataset from input {dataset_path} to {results_filepath}")
+IDS_TO_REMOVE.to_parquet(results_filepath)

--- a/src/easylink/steps/cascading/exclude_none.def
+++ b/src/easylink/steps/cascading/exclude_none.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./exclude_none.py /exclude_none.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow pyyaml
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /exclude_none.py '$@'

--- a/src/easylink/steps/cascading/exclude_none.py
+++ b/src/easylink/steps/cascading/exclude_none.py
@@ -1,0 +1,76 @@
+# STEP_NAME: determining_exclusions
+
+# REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml
+
+# PIPELINE_SCHEMA: main
+
+import logging
+import os
+from pathlib import Path
+
+import pandas as pd
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+
+def load_file(file_path, file_format=None):
+    logging.info(f"Loading file {file_path} with format {file_format}")
+    if file_format is None:
+        file_format = file_path.split(".")[-1]
+    if file_format == "parquet":
+        return pd.read_parquet(file_path)
+    raise ValueError(f"Unknown file format {file_format}")
+
+
+# LOAD INPUTS
+
+# INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS is list of filepaths which includes
+# the known_clusters filepath due to workaround
+dataset_paths = os.environ["INPUT_DATASETS_AND_INPUT_KNOWN_CLUSTERS_FILE_PATHS"].split(",")
+dataset_paths = [path for path in dataset_paths if "clusters" not in Path(path).stem]
+
+# for workaround, choose path based on INPUT_DATASET configuration
+splitter_choice = os.environ["INPUT_DATASET"]
+dataset_path = None
+for path in dataset_paths:
+    if splitter_choice == Path(path).stem:
+        dataset_path = path
+        break
+if dataset_path is None:
+    raise ValueError(f"No dataset matching {splitter_choice} found")
+
+# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of file paths.
+# There is one item in it that is a file with "clusters" in the filename.
+# That's the only item we're interested in here.
+# The other items may be there if this is coming from the user's input,
+# due to our workaround for only having one slot of user input.
+clusters_filepaths = [
+    path
+    for path in os.environ["KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"].split(",")
+    if "clusters" in Path(path).stem
+]
+if len(clusters_filepaths) > 1:
+    raise ValueError("Multiple known clusters files found")
+if len(clusters_filepaths) == 0:
+    raise ValueError("No known clusters file found")
+
+clusters_filepath = clusters_filepaths[0]
+
+clusters_df = load_file(clusters_filepath)
+
+# don't need to actually load the dataset,
+# since we will just save an empty ids_to_remove
+
+# SAVE OUTPUTS
+
+IDS_TO_REMOVE = pd.DataFrame(columns=["Record ID"])
+
+# DUMMY_CONTAINER_OUTPUT_PATHS is a single path to a file (results.parquet)
+results_filepath = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
+
+logging.info(f"Writing output for dataset from input {dataset_path} to {results_filepath}")
+IDS_TO_REMOVE.to_parquet(results_filepath)

--- a/src/easylink/steps/cascading/update_clusters_by_connected_components.def
+++ b/src/easylink/steps/cascading/update_clusters_by_connected_components.def
@@ -1,0 +1,22 @@
+
+Bootstrap: docker
+From: python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
+
+%files
+    ./update_clusters_by_connected_components.py /update_clusters_by_connected_components.py
+
+%post
+    # Create directories
+    mkdir -p /input_data
+    mkdir -p /extra_implementation_specific_input_data
+    mkdir -p /results
+    mkdir -p /diagnostics
+
+    # Install Python packages with specific versions
+    pip install pandas==2.1.2 pyarrow pyyaml networkx
+
+%environment
+    export LC_ALL=C
+
+%runscript
+    python /update_clusters_by_connected_components.py '$@'

--- a/src/easylink/steps/cascading/update_clusters_by_connected_components.py
+++ b/src/easylink/steps/cascading/update_clusters_by_connected_components.py
@@ -1,0 +1,99 @@
+# STEP_NAME: updating_clusters
+
+# REQUIREMENTS: pandas==2.1.2 pyarrow pyyaml networkx
+
+# PIPELINE_SCHEMA: main
+
+import logging
+import os
+from pathlib import Path
+
+import pandas as pd
+import networkx as nx
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+
+def load_file(file_path, file_format=None):
+    logging.info(f"Loading file {file_path} with format {file_format}")
+    if file_format is None:
+        file_format = file_path.split(".")[-1]
+    if file_format == "parquet":
+        return pd.read_parquet(file_path)
+    raise ValueError(f"Unknown file format {file_format}")
+
+
+# LOAD INPUTS and SAVE OUTPUTS
+
+# NEW_CLUSTERS_FILE_PATH is a path to a single file
+new_clusters_filepath = os.environ["NEW_CLUSTERS_FILE_PATH"]
+
+# KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS is a list of file paths.
+# There is one item in it that is a file with "clusters" in the filename.
+# That's the only item we're interested in here.
+# The other items may be there if this is coming from the user's input,
+# due to our workaround for only having one slot of user input.
+known_clusters_filepaths = [
+    path
+    for path in os.environ["KNOWN_CLUSTERS_AND_MAYBE_INPUT_DATASETS_FILE_PATHS"].split(",")
+    if "clusters" in Path(path).stem
+]
+if len(known_clusters_filepaths) > 1:
+    raise ValueError("Multiple known clusters files found")
+if len(known_clusters_filepaths) == 0:
+    raise ValueError("No known clusters file found")
+
+known_clusters_filepath = known_clusters_filepaths[0]
+known_clusters_df = load_file(known_clusters_filepath)
+
+# DUMMY_CONTAINER_OUTPUT_PATHS is a path to a single file (clusters.parquet)
+results_filepath = os.environ["DUMMY_CONTAINER_OUTPUT_PATHS"]
+Path(results_filepath).parent.mkdir(exist_ok=True, parents=True)
+
+new_clusters_df = load_file(new_clusters_filepath)
+
+def merge_clusters(known_clusters_df, new_clusters_df):
+    # Combine both dataframes
+    combined_df = pd.concat([known_clusters_df, new_clusters_df], ignore_index=True)
+
+    # Drop records with missing cluster IDs
+    combined_df = combined_df.dropna(subset=['Cluster ID'])
+
+    # Group by Cluster ID to get connected records
+    cluster_groups = combined_df.groupby('Cluster ID')['Input Record ID'].apply(list)
+
+    # Build a graph of all connections implied by cluster IDs
+    G = nx.Graph()
+    for group in cluster_groups:
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                G.add_edge(group[i], group[j])
+
+    # Add isolated nodes (records with unique clusters)
+    all_ids = set(combined_df['Input Record ID'])
+    G.add_nodes_from(all_ids)
+
+    # Compute connected components
+    components = list(nx.connected_components(G))
+
+    # Assign new cluster IDs
+    merged_data = []
+    for cluster_id, records in enumerate(components, start=1):
+        for record_id in records:
+            merged_data.append((record_id, cluster_id))
+
+    # Build the final DataFrame
+    merged_df = pd.DataFrame(merged_data, columns=['Input Record ID', 'Cluster ID'])
+
+    return merged_df
+
+output_df = merge_clusters(known_clusters_df, new_clusters_df)
+
+logging.info(
+    f"Writing output for dataset from input {new_clusters_filepath} to {results_filepath}"
+)
+output_df.to_parquet(results_filepath)

--- a/tests/e2e/test_pipelines_main_schema.py
+++ b/tests/e2e/test_pipelines_main_schema.py
@@ -184,3 +184,94 @@ def test_pipeline_with_fastLink(
             "\n\n*** END OF TEST ***\n"
             f"[{pipeline_specification}, {input_data}, {computing_environment}]\n"
         )
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not is_on_slurm(),
+    reason="Must be on slurm to run this test.",
+)
+@pytest.mark.parametrize(
+    "pipeline_specification, input_data, computing_environment, splink_results_csv",
+    [
+        # slurm pipeline_with_fastLink.yaml
+        (
+            "tests/specifications/e2e/pipeline_cascade.yaml",
+            "tests/specifications/e2e/input_data_dummy.yaml",
+            "tests/specifications/e2e/environment_slurm.yaml",
+            "tests/e2e/pipeline_splink_dummy_results.csv",
+        ),
+        # local pipeline_with_fastLink.yaml
+        (
+            "tests/specifications/e2e/pipeline_cascade.yaml",
+            "tests/specifications/e2e/input_data_dummy.yaml",
+            "tests/specifications/common/environment_local.yaml",
+            "tests/e2e/pipeline_splink_dummy_results.csv",
+        ),
+    ],
+)
+def test_pipeline_cascade(
+    pipeline_specification,
+    input_data,
+    computing_environment,
+    splink_results_csv,
+    test_specific_results_dir,
+    capsys,
+):
+    """Tests the 'easylink run' command
+
+    Notes
+    -----
+    We use various print statements in this test because they show up in the
+    Jenkins logs.
+    """
+
+    with capsys.disabled():  # disabled so we can monitor job submissions
+        print(
+            "\n\n*** RUNNING TEST ***\n"
+            f"[{pipeline_specification}, {input_data}, {computing_environment}]\n"
+        )
+
+        cmd = (
+            "easylink run "
+            f"-p {pipeline_specification} "
+            f"-i {input_data} "
+            f"-e {computing_environment} "
+            f"-o {str(test_specific_results_dir)} "
+            "--no-timestamp "
+            "--schema main "
+        )
+        subprocess.run(
+            cmd,
+            shell=True,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=True,
+        )
+        final_output = test_specific_results_dir / "result.parquet"
+        assert final_output.exists()
+        # Check that the results file matches the expected value
+        results = (
+            pd.read_parquet(final_output)
+            .sort_values("Input Record ID")
+            .reset_index(drop=True)
+        )
+        splink_results = pd.read_csv(splink_results_csv)
+        # TODO: Cascading hasn't actually found any additional records here,
+        # because they are currently all so easy to link that the first model
+        # gets them all.
+        # We should make our dummy files a bit harder.
+        # Tricky code from fastLink test.
+        assert frozenset(
+            results.groupby("Cluster ID")["Input Record ID"].apply(frozenset)
+        ) == frozenset(
+            splink_results.groupby("Cluster ID")["Input Record ID"].apply(frozenset)
+        )
+
+        assert (test_specific_results_dir / Path(pipeline_specification).name).exists()
+        assert (test_specific_results_dir / Path(input_data).name).exists()
+        assert (test_specific_results_dir / Path(computing_environment).name).exists()
+
+        print(
+            "\n\n*** END OF TEST ***\n"
+            f"[{pipeline_specification}, {input_data}, {computing_environment}]\n"
+        )

--- a/tests/specifications/e2e/pipeline_cascade.yaml
+++ b/tests/specifications/e2e/pipeline_cascade.yaml
@@ -1,0 +1,134 @@
+steps:
+  entity_resolution:
+    iterate:
+      - substeps:
+          determining_exclusions_and_removing_records:
+            parallel:
+              - determining_exclusions:
+                  implementation:
+                    name: default_determining_exclusions
+                    configuration:
+                      INPUT_DATASET: input_file_1
+                removing_records:
+                  implementation:
+                    name: default_removing_records
+                    configuration:
+                      INPUT_DATASET: input_file_1
+              - determining_exclusions:
+                  implementation:
+                    name: default_determining_exclusions
+                    configuration:
+                      INPUT_DATASET: input_file_2
+                removing_records:
+                  implementation:
+                    name: default_removing_records
+                    configuration:
+                      INPUT_DATASET: input_file_2
+          clustering:
+            substeps:
+              clusters_to_links:
+                implementation:
+                  name: default_clusters_to_links
+              linking:
+                substeps:
+                  pre-processing:
+                    parallel:
+                    - implementation:
+                        name: dummy_pre-processing
+                        configuration: 
+                          INPUT_DATASET: input_file_1
+                    - implementation:
+                        name: dummy_pre-processing
+                        configuration: 
+                          INPUT_DATASET: input_file_2
+                  schema_alignment:
+                    implementation:
+                      name: default_schema_alignment
+                  blocking_and_filtering:
+                    implementation:
+                      name: splink_blocking_and_filtering
+                      configuration:
+                        BLOCKING_RULES: "'l.last_name == r.last_name'"
+                  evaluating_pairs:
+                    implementation:
+                      name: splink_evaluating_pairs
+                      configuration:
+                        BLOCKING_RULES_FOR_TRAINING: "'l.first_name == r.first_name,l.last_name == r.last_name'"
+                        COMPARISONS: "'first_name:exact,last_name:exact'"
+                        PROBABILITY_TWO_RANDOM_RECORDS_MATCH: 0.01 
+                        THRESHOLD_MATCH_PROBABILITY: 0.1
+              links_to_clusters:
+                implementation:
+                  name: splink_links_to_clusters
+                  configuration:
+                    THRESHOLD_MATCH_PROBABILITY: 0.1
+          updating_clusters:
+            implementation:
+              name: default_updating_clusters
+      - substeps:
+          determining_exclusions_and_removing_records:
+            parallel:
+              - determining_exclusions:
+                  implementation:
+                    name: exclude_clustered
+                    configuration:
+                      INPUT_DATASET: input_file_1
+                removing_records:
+                  implementation:
+                    name: default_removing_records
+                    configuration:
+                      INPUT_DATASET: input_file_1
+              - determining_exclusions:
+                  implementation:
+                    name: exclude_none
+                    configuration:
+                      INPUT_DATASET: input_file_2
+                removing_records:
+                  implementation:
+                    name: default_removing_records
+                    configuration:
+                      INPUT_DATASET: input_file_2
+          clustering:
+            substeps:
+              clusters_to_links:
+                implementation:
+                  name: default_clusters_to_links
+              linking:
+                substeps:
+                  pre-processing:
+                    parallel:
+                    - implementation:
+                        name: dummy_pre-processing
+                        configuration: 
+                          INPUT_DATASET: input_file_1
+                    - implementation:
+                        name: dummy_pre-processing
+                        configuration: 
+                          INPUT_DATASET: input_file_2
+                  schema_alignment:
+                    implementation:
+                      name: default_schema_alignment
+                  blocking_and_filtering:
+                    implementation:
+                      name: splink_blocking_and_filtering
+                      configuration:
+                        BLOCKING_RULES: "'l.first_name == r.first_name'"
+                  evaluating_pairs:
+                    implementation:
+                      name: splink_evaluating_pairs
+                      configuration:
+                        BLOCKING_RULES_FOR_TRAINING: "'l.first_name == r.first_name,l.last_name == r.last_name'"
+                        COMPARISONS: "'first_name:exact,last_name:exact'"
+                        PROBABILITY_TWO_RANDOM_RECORDS_MATCH: 0.01 
+                        THRESHOLD_MATCH_PROBABILITY: 0.1
+              links_to_clusters:
+                implementation:
+                  name: splink_links_to_clusters
+                  configuration:
+                    THRESHOLD_MATCH_PROBABILITY: 0.1
+          updating_clusters:
+            implementation:
+              name: update_clusters_by_connected_components
+  canonicalizing_and_downstream_analysis:
+    implementation:
+      name: dummy_canonicalizing_and_downstream_analysis


### PR DESCRIPTION
## Add implementations for cascading

### Description
- *Category*: implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/SSCI-2285
- *Research reference*: None

### Changes and notes

Enables cascading of the style between PVS **modules**.

### Verification and Testing

Ran e2e test introduced in this branch.

Because the current dummy input files are so easy to link that cascading is not meaningfully exercised (all links are found in first pass), I also tested this manually using the input files @tylerdy is creating in #229.