### PR TITLE
Rename dummy implementations

### DIFF
--- a/docs/source/user_guide/tutorials/pipeline_demo_improved.yaml
+++ b/docs/source/user_guide/tutorials/pipeline_demo_improved.yaml
@@ -37,7 +37,7 @@ steps:
                     configuration: 
                       INPUT_DATASET: input_file_ssa
                 - implementation:
-                    name: dummy_pre-processing
+                    name: no_pre-processing
                     configuration: 
                       INPUT_DATASET: input_file_w2
               schema_alignment:
@@ -68,4 +68,4 @@ steps:
           name: default_updating_clusters
   canonicalizing_and_downstream_analysis:
     implementation:
-      name: dummy_canonicalizing_and_downstream_analysis
+      name: save_clusters

--- a/docs/source/user_guide/tutorials/pipeline_demo_naive.yaml
+++ b/docs/source/user_guide/tutorials/pipeline_demo_naive.yaml
@@ -37,7 +37,7 @@ steps:
                     configuration: 
                       INPUT_DATASET: input_file_ssa
                 - implementation:
-                    name: dummy_pre-processing
+                    name: no_pre-processing
                     configuration: 
                       INPUT_DATASET: input_file_w2
               schema_alignment:
@@ -68,4 +68,4 @@ steps:
           name: default_updating_clusters
   canonicalizing_and_downstream_analysis:
     implementation:
-      name: dummy_canonicalizing_and_downstream_analysis
+      name: save_clusters

--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -285,17 +285,21 @@ default_updating_clusters:
   script_cmd: python /default_updating_clusters.py
   outputs:
     clusters: clusters.parquet
-dummy_canonicalizing_and_downstream_analysis:
+# NOTE: This was made from dummy_canonicalizing_and_downstream_analysis.py,
+# if rebuilding change the name of that file to save_clusters.py
+save_clusters:
   steps:
   - canonicalizing_and_downstream_analysis
-  image_name: main/dummy_canonicalizing_and_downstream_analysis.sif
+  image_name: zmbc/save_clusters.sif
   script_cmd: python /dummy_canonicalizing_and_downstream_analysis.py
   outputs:
     analysis_output: result.parquet
-dummy_pre-processing:
+# NOTE: This was made from dummy_pre-processing.py,
+# if rebuilding change the name of that file to no_pre-processing.py
+no_pre-processing:
   steps:
   - pre-processing
-  image_name: main/dummy_pre-processing.sif
+  image_name: zmbc/no_pre-processing.sif
   script_cmd: python /dummy_pre-processing.py
   outputs:
     dataset: dataset

--- a/src/easylink/implementation_metadata.yaml
+++ b/src/easylink/implementation_metadata.yaml
@@ -290,7 +290,7 @@ default_updating_clusters:
 save_clusters:
   steps:
   - canonicalizing_and_downstream_analysis
-  image_name: zmbc/save_clusters.sif
+  image_name: main/save_clusters.sif
   script_cmd: python /dummy_canonicalizing_and_downstream_analysis.py
   outputs:
     analysis_output: result.parquet
@@ -299,7 +299,7 @@ save_clusters:
 no_pre-processing:
   steps:
   - pre-processing
-  image_name: zmbc/no_pre-processing.sif
+  image_name: main/no_pre-processing.sif
   script_cmd: python /dummy_pre-processing.py
   outputs:
     dataset: dataset

--- a/tests/specifications/e2e/pipeline_cascade.yaml
+++ b/tests/specifications/e2e/pipeline_cascade.yaml
@@ -34,11 +34,11 @@ steps:
                   pre-processing:
                     clones:
                     - implementation:
-                        name: dummy_pre-processing
+                        name: no_pre-processing
                         configuration: 
                           INPUT_DATASET: input_file_1
                     - implementation:
-                        name: dummy_pre-processing
+                        name: no_pre-processing
                         configuration: 
                           INPUT_DATASET: input_file_2
                   schema_alignment:
@@ -98,11 +98,11 @@ steps:
                   pre-processing:
                     clones:
                     - implementation:
-                        name: dummy_pre-processing
+                        name: no_pre-processing
                         configuration: 
                           INPUT_DATASET: input_file_1
                     - implementation:
-                        name: dummy_pre-processing
+                        name: no_pre-processing
                         configuration: 
                           INPUT_DATASET: input_file_2
                   schema_alignment:
@@ -131,4 +131,4 @@ steps:
               name: update_clusters_by_connected_components
   canonicalizing_and_downstream_analysis:
     implementation:
-      name: dummy_canonicalizing_and_downstream_analysis
+      name: save_clusters

--- a/tests/specifications/e2e/pipeline_splink_dummy.yaml
+++ b/tests/specifications/e2e/pipeline_splink_dummy.yaml
@@ -33,11 +33,11 @@ steps:
               pre-processing:
                 clones:
                 - implementation:
-                    name: dummy_pre-processing
+                    name: no_pre-processing
                     configuration: 
                       INPUT_DATASET: input_file_1
                 - implementation:
-                    name: dummy_pre-processing
+                    name: no_pre-processing
                     configuration: 
                       INPUT_DATASET: input_file_2
               schema_alignment:
@@ -66,4 +66,4 @@ steps:
           name: default_updating_clusters
   canonicalizing_and_downstream_analysis:
     implementation:
-      name: dummy_canonicalizing_and_downstream_analysis
+      name: save_clusters

--- a/tests/specifications/e2e/pipeline_with_fastLink.yaml
+++ b/tests/specifications/e2e/pipeline_with_fastLink.yaml
@@ -33,11 +33,11 @@ steps:
               pre-processing:
                 clones:
                 - implementation:
-                    name: dummy_pre-processing
+                    name: no_pre-processing
                     configuration: 
                       INPUT_DATASET: input_file_1
                 - implementation:
-                    name: dummy_pre-processing
+                    name: no_pre-processing
                     configuration: 
                       INPUT_DATASET: input_file_2
               schema_alignment:
@@ -64,4 +64,4 @@ steps:
           name: default_updating_clusters
   canonicalizing_and_downstream_analysis:
     implementation:
-      name: dummy_canonicalizing_and_downstream_analysis
+      name: save_clusters


### PR DESCRIPTION
## Rename dummy implementations

### Description
- *Category*: refactor
- *JIRA issue*: None
- *Research reference*: None

### Changes and notes

Renames the two implementations with "dummy" in the name still being used in the tutorial.

### Verification and Testing

Ran `pytest tests/e2e/test_pipelines_main_schema.py::test_pipeline_splink[docs/source/user_guide/tutorials/pipeline_demo_improved.yaml-docs/source/user_guide/tutorials/input_data_demo.yaml-tests/specifications/common/environment_local.yaml-tests/e2e/pipeline_improved_results.csv] --runslow`